### PR TITLE
Option to opaquely paint grayscale territory prediction on board

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -383,6 +383,7 @@ public class Config {
 
   public void toggleKataGoEstimate() {
     showKataGoEstimate = !showKataGoEstimate;
+    uiConfig.put("show-katago-estimate", showKataGoEstimate);
   }
 
   public void cycleKataGoEstimateMode() {
@@ -410,6 +411,7 @@ public class Config {
         kataGoEstimateMode = "small";
         break;
     }
+    uiConfig.put("katago-estimate-mode", kataGoEstimateMode);
   }
 
   public void toggleShowStatus() {

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -58,6 +58,7 @@ public class Config {
   public boolean showKataGoEstimateOnSubboard = true;
   public boolean showKataGoEstimateOnMainboard = true;
   public String kataGoEstimateMode = "small+dead";
+  public boolean kataGoEstimateBlend = true;
 
   public boolean showStatus = true;
   public boolean showBranch = true;
@@ -241,6 +242,7 @@ public class Config {
     showKataGoEstimateOnSubboard = uiConfig.optBoolean("show-katago-estimate-onsubboard", true);
     showKataGoEstimateOnMainboard = uiConfig.optBoolean("show-katago-estimate-onmainboard", true);
     kataGoEstimateMode = uiConfig.optString("katago-estimate-mode", "small+dead");
+    kataGoEstimateBlend = uiConfig.optBoolean("katago-estimate-blend", true);
     showWinrateInSuggestion = uiConfig.optBoolean("show-winrate-in-suggestion", true);
     showPlayoutsInSuggestion = uiConfig.optBoolean("show-playouts-in-suggestion", true);
     showScoremeanInSuggestion = uiConfig.optBoolean("show-scoremean-in-suggestion", true);
@@ -414,6 +416,11 @@ public class Config {
     uiConfig.put("katago-estimate-mode", kataGoEstimateMode);
   }
 
+  public void toggleKataGoEstimateBlend() {
+    kataGoEstimateBlend = !kataGoEstimateBlend;
+    uiConfig.put("katago-estimate-blend", kataGoEstimateBlend);
+  }
+
   public void toggleShowStatus() {
     this.showStatus = !this.showStatus;
     Lizzie.config.uiConfig.put("show-status", showStatus);
@@ -546,6 +553,7 @@ public class Config {
     ui.put("show-katago-estimate-onsubboard", true);
     ui.put("show-katago-estimate-onmainboard", true);
     ui.put("katago-estimate-mode", "small");
+    ui.put("katago-estimate-blend", true);
     config.put("ui", ui);
     return config;
   }

--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -1789,13 +1789,20 @@ public class BoardRenderer {
       int stoneY = scaledMarginHeight + squareHeight * y;
       // g.setColor(Color.BLACK);
 
-      int grey = (estimate > 0) ? 0 : 255;
-      double alpha = 255 * Math.abs(estimate);
+      boolean blend = Lizzie.config.kataGoEstimateBlend;
+      int grey;
+      double alpha = 255;
+      if (blend) {
+        grey = (estimate > 0) ? 0 : 255;
+        alpha *= Math.abs(estimate);
+      } else {
+        grey = roundToInt((1 - estimate) * 255 / 2.0);
+      }
 
       // Large rectangles (will go behind stones).
 
       if (drawLarge) {
-        Color cl = new Color(grey, grey, grey, roundToInt(0.75 * alpha));
+        Color cl = new Color(grey, grey, grey, roundToInt(blend ? 0.75 * alpha : alpha));
         gl.setColor(cl);
         gl.fillRect(
             (int) (stoneX - squareWidth * 0.5),
@@ -1818,7 +1825,7 @@ public class BoardRenderer {
       if (drawSmall && allowed) {
         double lengthFactor = drawSize ? 2 * convertLength(estimate) : 1.2;
         int length = (int) (lengthFactor * stoneRadius);
-        int ialpha = drawSize ? 180 : roundToInt(alpha);
+        int ialpha = (blend && drawSize) ? 180 : roundToInt(alpha);
         Color cl = new Color(grey, grey, grey, ialpha);
         gs.setColor(cl);
         gs.fillRect(stoneX - length / 2, stoneY - length / 2, length, length);

--- a/src/main/java/featurecat/lizzie/gui/Input.java
+++ b/src/main/java/featurecat/lizzie/gui/Input.java
@@ -451,6 +451,8 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
         if (Lizzie.leelaz.isKataGo) {
           if (e.isAltDown()) {
             Lizzie.frame.toggleEstimateByZen();
+          } else if (e.isShiftDown()) {
+            if (Lizzie.config.showKataGoEstimate) Lizzie.config.toggleKataGoEstimateBlend();
           } else {
             if (e.isControlDown()) {
               // ctrl-. cycles modes, but only if estimates being displayed

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -916,6 +916,22 @@ public class Menu extends JMenuBar {
           }
         });
 
+    final JCheckBoxMenuItem kataEstimateBlend =
+        new JCheckBoxMenuItem(resourceBundle.getString("Menu.view.kataGo.kataEstimate.blend"));
+    kataEstimateBlend.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            Lizzie.config.toggleKataGoEstimateBlend();
+            try {
+              Lizzie.config.save();
+            } catch (IOException es) {
+              // TODO Auto-generated catch block
+            }
+          }
+        });
+    kataEstimate.add(kataEstimateBlend);
+
     viewMenu.addMenuListener(
         new MenuListener() {
           public void menuSelected(MenuEvent e) {
@@ -960,6 +976,7 @@ public class Menu extends JMenuBar {
             kataEstimateModeLargeAndStones.setState(
                 Lizzie.config.kataGoEstimateMode.equals("large+stones"));
             kataEstimateModeSize.setState(Lizzie.config.kataGoEstimateMode.equals("size"));
+            kataEstimateBlend.setState(Lizzie.config.kataGoEstimateBlend);
             if (Lizzie.config.uiConfig.getBoolean("win-rate-always-black"))
               winrateAlwaysBlack.setState(true);
             else winrateAlwaysBlack.setState(false);

--- a/src/main/resources/l10n/DisplayStrings.properties
+++ b/src/main/resources/l10n/DisplayStrings.properties
@@ -253,6 +253,7 @@ Menu.view.kataGo.kataEstimate.mode.largeAndSmall=Large + small everywhere
 Menu.view.kataGo.kataEstimate.mode.largeAndDead=Large + small on "dead" stones
 Menu.view.kataGo.kataEstimate.mode.largeAndStones=Large + small on all stones
 Menu.view.kataGo.kataEstimate.mode.size=Small, of varying size
+Menu.view.kataGo.kataEstimate.blend=Blend with board
 Menu.game=Game
 Menu.game.newGame=NewGame(N)
 Menu.game.continueGameBlack=Continue(Play black)


### PR DESCRIPTION
Following up on https://github.com/featurecat/lizzie/pull/571#issuecomment-515765015. The keyboard shortcut to toggle this setting is **Shift-Period**.