### PR TITLE
Remove redundant score display to fix #683

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -715,7 +715,6 @@ public class Leelaz {
 
   public class WinrateStats {
     public double maxWinrate;
-    public double maxScoreMean;
     public int totalPlayouts;
 
     public WinrateStats(double maxWinrate, int totalPlayouts) {
@@ -743,9 +742,6 @@ public class Leelaz {
       stats.totalPlayouts = totalPlayouts;
 
       stats.maxWinrate = BoardData.getWinrateFromBestMoves(moves);
-      if (isKataGo) {
-        stats.maxScoreMean = BoardData.getScoreMeanFromBestMoves(moves);
-      }
     }
 
     return stats;

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -910,7 +910,6 @@ public class LizzieFrame extends MainFrame {
 
     Leelaz.WinrateStats stats = Lizzie.leelaz.getWinrateStats();
     double curWR = stats.maxWinrate; // winrate on this move
-    double curSM = stats.maxScoreMean; // mean score on this move
     boolean validWinrate = (stats.totalPlayouts > 0); // and whether it was actually calculated
     if (!validWinrate) {
       curWR = Lizzie.board.getHistory().getData().winrate;
@@ -924,13 +923,11 @@ public class LizzieFrame extends MainFrame {
     if (!validWinrate) {
       curWR = 100 - lastWR; // display last move's winrate for now (with color difference)
     }
-    double whiteWR, blackWR, blackSM;
+    double whiteWR, blackWR;
     if (Lizzie.board.getData().blackToPlay) {
       blackWR = curWR;
-      blackSM = curSM;
     } else {
       blackWR = 100 - curWR;
-      blackSM = -curSM;
     }
 
     whiteWR = 100 - blackWR;
@@ -1044,14 +1041,6 @@ public class LizzieFrame extends MainFrame {
           winString,
           barPosxB + maxBarwidth - sw - 2 * strokeRadius,
           posY + barHeight - 2 * strokeRadius);
-      if (Lizzie.leelaz.isKataGo) {
-        String scoreString = String.format("%.1f", blackSM);
-        sw = g.getFontMetrics().stringWidth(scoreString);
-        g.drawString(
-            scoreString,
-            barPosxB + maxBarwidth / 2 - sw / 2 - strokeRadius,
-            posY + barHeight - 2 * strokeRadius);
-      }
 
       g.setColor(Color.GRAY);
       Stroke oldstroke = g.getStroke();

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -1454,9 +1454,6 @@ public class Board implements LeelazListener {
     Leelaz.WinrateStats stats = Lizzie.leelaz.getWinrateStats();
     if (stats.maxWinrate >= 0 && stats.totalPlayouts > history.getData().getPlayouts()) {
       history.getData().winrate = stats.maxWinrate;
-      if (Lizzie.leelaz.isKataGo) {
-        history.getData().scoreMean = stats.maxScoreMean;
-      }
       // we won't set playouts here. but setting winrate is ok... it shows the user that we are
       // computing. i think its fine.
     }


### PR DESCRIPTION
These patches revert parts of my past PR #542 (2814463) because #546 (c8ac633) gives a better implementation of the same feature. :-)

We wrote them independently, and the estimated score is doubly shown above and below the winrate bar now...
