### PR TITLE
Fix wrong variation number on subboard

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -2005,6 +2005,7 @@ public class BoardRenderer {
 
   public void increaseBestmoveIndexSub(int n) {
     if (bestmoveIndexSub + n >= 0) bestmoveIndexSub = bestmoveIndexSub + n;
+    getBestMove(); // call this here to correct exceeding bestmoveIndexSub
   }
 
   public void clearBeforeMove() {


### PR DESCRIPTION
Suppose that there are three suggested moves now, for example. Right-clicking the subboard repeatedly, we see "4" at the right bottom corner in the subboard. It is immediately corrected to "3" when pondering is on. But the wrong "4" remains when pondering is off. The present PR fixes this issue.
