### PR TITLE
Fix empty dialogs on Linux (ref. #616 #642)

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/AvoidMoveDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/AvoidMoveDialog.java
@@ -9,7 +9,6 @@ import java.text.NumberFormat;
 import java.util.ResourceBundle;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
-import javax.swing.JDialog;
 import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -19,7 +18,7 @@ import javax.swing.SwingConstants;
 import javax.swing.text.DocumentFilter;
 import javax.swing.text.InternationalFormatter;
 
-public class AvoidMoveDialog extends JDialog {
+public class AvoidMoveDialog extends LizzieDialog {
   public final ResourceBundle resourceBundle = MainFrame.resourceBundle;
   private JRadioButton rdoAvoid;
   private JRadioButton rdoAllow;

--- a/src/main/java/featurecat/lizzie/gui/BasicLizziePaneUI.java
+++ b/src/main/java/featurecat/lizzie/gui/BasicLizziePaneUI.java
@@ -204,7 +204,7 @@ public class BasicLizziePaneUI extends LizziePaneUI implements SwingConstants {
    * @return a <code>RootPaneContainer</code> object, containing the lizziePane.
    */
   protected RootPaneContainer createFloatingWindow(LizziePane lizziePane) {
-    class LizziePaneDialog extends JDialog {
+    class LizziePaneDialog extends LizzieDialog {
       public LizziePaneDialog(Frame owner, String title, boolean modal) {
         super(owner, title, modal);
       }

--- a/src/main/java/featurecat/lizzie/gui/ChangeMoveDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ChangeMoveDialog.java
@@ -14,7 +14,6 @@ import java.util.ResourceBundle;
 import javax.swing.Action;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
-import javax.swing.JDialog;
 import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -26,7 +25,7 @@ import javax.swing.event.ChangeListener;
 import javax.swing.text.DocumentFilter;
 import javax.swing.text.InternationalFormatter;
 
-public class ChangeMoveDialog extends JDialog {
+public class ChangeMoveDialog extends LizzieDialog {
   public final ResourceBundle resourceBundle = MainFrame.resourceBundle;
   private JRadioButton rdoChangeCoord;
   private JRadioButton rdoPass;

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -42,7 +42,6 @@ import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ResourceBundle;
@@ -99,14 +98,13 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class ConfigDialog extends JDialog {
+public class ConfigDialog extends LizzieDialog {
   public final ResourceBundle resourceBundle = MainFrame.resourceBundle;
 
   public String enginePath = "";
   public String weightPath = "";
   public String commandHelp = "";
 
-  private String osName;
   private Path curPath;
   private BufferedInputStream inputStream;
   private JSONObject leelazConfig;
@@ -223,9 +221,7 @@ public class ConfigDialog extends JDialog {
   public ConfigDialog() {
     setTitle(resourceBundle.getString("LizzieConfig.title.config"));
     setModalityType(ModalityType.APPLICATION_MODAL);
-    if (isWindows()) { // avoid suspicious behavior on Linux (#616)
-      setType(Type.POPUP);
-    }
+    setType(Type.POPUP);
     setBounds(100, 100, 661, 716);
     getContentPane().setLayout(new BorderLayout());
     JPanel buttonPane = new JPanel();
@@ -792,7 +788,6 @@ public class ConfigDialog extends JDialog {
         String.valueOf(leelazConfig.getInt("max-game-thinking-time-seconds")));
     chkPrintEngineLog.setSelected(leelazConfig.getBoolean("print-comms"));
     curPath = (new File("")).getAbsoluteFile().toPath();
-    osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
     setShowLcbWinrate();
     JLabel lblBoardSize = new JLabel(resourceBundle.getString("LizzieConfig.title.boardSize"));
     lblBoardSize.setBounds(6, 6, 67, 16);
@@ -2150,10 +2145,6 @@ public class ConfigDialog extends JDialog {
     public boolean isCellEditable(int row, int col) {
       return true;
     }
-  }
-
-  public boolean isWindows() {
-    return osName != null && !osName.contains("darwin") && osName.contains("win");
   }
 
   private void setShowLcbWinrate() {

--- a/src/main/java/featurecat/lizzie/gui/EngineParameter.java
+++ b/src/main/java/featurecat/lizzie/gui/EngineParameter.java
@@ -9,7 +9,6 @@ import java.awt.event.ActionListener;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import javax.swing.JButton;
-import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -17,7 +16,7 @@ import javax.swing.JTextField;
 import javax.swing.JTextPane;
 import javax.swing.border.EmptyBorder;
 
-public class EngineParameter extends JDialog {
+public class EngineParameter extends LizzieDialog {
 
   public String enginePath = "";
   public String weightPath = "";

--- a/src/main/java/featurecat/lizzie/gui/GameInfoDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/GameInfoDialog.java
@@ -16,7 +16,6 @@ import java.awt.GridLayout;
 import java.awt.Insets;
 import java.text.DecimalFormat;
 import javax.swing.JButton;
-import javax.swing.JDialog;
 import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -24,7 +23,7 @@ import javax.swing.JTextField;
 import javax.swing.border.EmptyBorder;
 
 /** @author unknown */
-public class GameInfoDialog extends JDialog {
+public class GameInfoDialog extends LizzieDialog {
   // create formatters
   public static final DecimalFormat FORMAT_KOMI = new DecimalFormat("#0.0#");
   public static final DecimalFormat FORMAT_HANDICAP = new DecimalFormat("0");

--- a/src/main/java/featurecat/lizzie/gui/GtpConsolePane.java
+++ b/src/main/java/featurecat/lizzie/gui/GtpConsolePane.java
@@ -11,7 +11,6 @@ import java.awt.event.ActionEvent;
 import java.io.IOException;
 import java.util.ResourceBundle;
 import javax.swing.BorderFactory;
-import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JRootPane;
@@ -27,7 +26,7 @@ import javax.swing.text.html.HTMLDocument;
 import javax.swing.text.html.StyleSheet;
 import org.json.JSONArray;
 
-public class GtpConsolePane extends JDialog {
+public class GtpConsolePane extends LizzieDialog {
   private static final ResourceBundle resourceBundle = MainFrame.resourceBundle;
 
   // Display Comment

--- a/src/main/java/featurecat/lizzie/gui/LizzieDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieDialog.java
@@ -1,0 +1,47 @@
+package featurecat.lizzie.gui;
+
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.Window;
+import java.util.Locale;
+import javax.swing.JDialog;
+
+// Use `LizzieDialog` instead of `JDialog` to avoid empty dialogs like #616 on Linux.
+
+public class LizzieDialog extends JDialog {
+  private String osName;
+
+  public LizzieDialog() {
+    super();
+    setOsName();
+  }
+
+  public LizzieDialog(Window owner) {
+    super(owner);
+    setOsName();
+  }
+
+  public LizzieDialog(Frame owner, String title, boolean modal) {
+    super(owner, title, modal);
+    setOsName();
+  }
+
+  public LizzieDialog(Dialog owner, String title, boolean modal) {
+    super(owner, title, modal);
+    setOsName();
+  }
+
+  private void setOsName() {
+    osName = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
+  }
+
+  public void setType(Window.Type type) {
+    // avoid suspicious behavior on Linux (#616)
+    if (type == Type.POPUP && !isWindows()) return;
+    super.setType(type);
+  }
+
+  public boolean isWindows() {
+    return osName != null && !osName.contains("darwin") && osName.contains("win");
+  }
+}

--- a/src/main/java/featurecat/lizzie/gui/NewGameDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/NewGameDialog.java
@@ -17,7 +17,6 @@ import java.text.ParseException;
 import java.util.ResourceBundle;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
-import javax.swing.JDialog;
 import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -25,7 +24,7 @@ import javax.swing.JTextField;
 import javax.swing.border.EmptyBorder;
 
 /** @author unknown */
-public class NewGameDialog extends JDialog {
+public class NewGameDialog extends LizzieDialog {
   private static final ResourceBundle resourceBundle = MainFrame.resourceBundle;
   // create formatters
   public static final DecimalFormat FORMAT_KOMI = new DecimalFormat("#0.0");

--- a/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/OnlineDialog.java
@@ -49,7 +49,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.swing.JButton;
-import javax.swing.JDialog;
 import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -63,7 +62,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class OnlineDialog extends JDialog {
+public class OnlineDialog extends LizzieDialog {
   public final ResourceBundle resourceBundle = MainFrame.resourceBundle;
   private ScheduledExecutorService online = Executors.newScheduledThreadPool(1);
   private ScheduledFuture<?> schedule = null;


### PR DESCRIPTION
There are similar issues as #616 for Alt-M etc. This PR fixes them at once.

They are very annoying as the empty dialog holds the focus and prevents any window operations. I need to hit Ctrl-Alt-F2 and type a kill command on a virtual console to escape from the trap.

To developers:
Please use `LizzieDialog` instead of `JDialog` to avoid the suspicious behavior of `setType(Type.POPUP)` on Linux.
