### PR TITLE
Restore all checks in View > Panel at startup for #777

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -322,11 +322,11 @@ public class Config {
   }
 
   public void toggleShowCaptured() {
-    this.showCaptured = !this.showCaptured;
+    this.showCaptured = toggleUIConfig("show-captured");
   }
 
   public void toggleShowWinrate() {
-    this.showWinrate = !this.showWinrate;
+    this.showWinrate = toggleUIConfig("show-winrate");
   }
 
   public void toggleLargeWinrate() {
@@ -339,11 +339,11 @@ public class Config {
   }
 
   public void toggleShowVariationGraph() {
-    this.showVariationGraph = !this.showVariationGraph;
+    this.showVariationGraph = toggleUIConfig("show-variation-graph");
   }
 
   public void toggleShowComment() {
-    this.showComment = !this.showComment;
+    this.showComment = toggleUIConfig("show-comment");
   }
 
   public void toggleShowCommentNodeColor() {
@@ -376,7 +376,7 @@ public class Config {
   }
 
   public void toggleShowSubBoard() {
-    showSubBoard = !showSubBoard;
+    showSubBoard = toggleUIConfig("show-subboard");
   }
 
   public void toggleShowPolicy() {
@@ -424,13 +424,13 @@ public class Config {
   }
 
   public void toggleShowStatus() {
-    this.showStatus = !this.showStatus;
-    Lizzie.config.uiConfig.put("show-status", showStatus);
-    try {
-      Lizzie.config.save();
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    this.showStatus = toggleUIConfig("show-status");
+  }
+
+  private boolean toggleUIConfig(String key) {
+    boolean newValue = !uiConfig.getBoolean(key);
+    uiConfig.put(key, newValue);
+    return newValue;
   }
 
   public boolean showLargeSubBoard() {

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -330,8 +330,8 @@ public class Config {
   }
 
   public void toggleLargeWinrate() {
-    this.largeSubBoard = false;
-    this.largeWinrate = !this.largeWinrate;
+    this.largeSubBoard = setUIConfigBoolean("large-subboard", false);
+    this.largeWinrate = toggleUIConfig("large-winrate");
   }
 
   public void toggleShowLcbWinrate() {
@@ -363,8 +363,8 @@ public class Config {
   }
 
   public void toggleLargeSubBoard() {
-    this.largeWinrate = false;
-    this.largeSubBoard = !this.largeSubBoard;
+    this.largeWinrate = setUIConfigBoolean("large-winrate", false);
+    this.largeSubBoard = toggleUIConfig("large-subboard");
   }
 
   public void toggleCoordinates() {
@@ -428,9 +428,12 @@ public class Config {
   }
 
   private boolean toggleUIConfig(String key) {
-    boolean newValue = !uiConfig.getBoolean(key);
-    uiConfig.put(key, newValue);
-    return newValue;
+    return setUIConfigBoolean(key, !uiConfig.getBoolean(key));
+  }
+
+  private boolean setUIConfigBoolean(String key, boolean value) {
+    uiConfig.put(key, value);
+    return value;
   }
 
   public boolean showLargeSubBoard() {

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -31,7 +31,7 @@ public class Lizzie {
     config = new Config();
     frame = config.panelUI ? new LizzieMain() : new LizzieFrame();
     gtpConsole = new GtpConsolePane(frame);
-    gtpConsole.setVisible(config.leelazConfig.optBoolean("print-comms", false));
+    gtpConsole.setVisible(config.persistedUi.optBoolean("gtp-console-opened", false));
     initializeEngineManager();
   }
 

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -89,6 +89,7 @@ public class Lizzie {
     board.autosaveToMemory();
 
     try {
+      config.save();
       config.persist();
     } catch (IOException e) {
       e.printStackTrace(); // Failed to save config

--- a/src/main/java/featurecat/lizzie/util/WindowPosition.java
+++ b/src/main/java/featurecat/lizzie/util/WindowPosition.java
@@ -39,6 +39,7 @@ public class WindowPosition {
 
     ui.put("window-maximized", false);
     ui.put("toolbar-position", "South");
+    ui.put("gtp-console-opened", false);
 
     return ui;
   }
@@ -52,6 +53,7 @@ public class WindowPosition {
     ui.put("window-maximized", windowIsMaximized);
     ui.put("toolbar-position", Lizzie.config.toolbarPosition);
     ui.put("board-position-proportion", Lizzie.frame.boardPositionProportion);
+    ui.put("gtp-console-opened", Lizzie.gtpConsole.isVisible());
 
     JSONArray mainPos = new JSONArray();
     if (!windowIsMaximized) {


### PR DESCRIPTION
Lizzie forgets the visibility of GTP console in every run. It is opened at startup only if Settings > Engine > Print Engine Log is checked.

This PR makes Lizzie keep all the checks in the menu View > Panel and restore them automatically at next startup.
