### PR TITLE
Fix wrong "Engine is loading..."

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -129,6 +129,7 @@ public class EngineManager {
     } catch (IOException e) {
       e.printStackTrace();
     }
+    Lizzie.frame.refresh();
   }
 
   public void refresh() throws JSONException, IOException {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -344,14 +344,6 @@ public class Leelaz {
       } else if (line.equals("\n")) {
         // End of response
       } else if (line.startsWith("info")) {
-        if (!isLoaded) {
-          Lizzie.frame.refresh();
-        }
-        isLoaded = true;
-        // Clear switching prompt
-        switching = false;
-        // Display engine command in the title
-        Lizzie.frame.updateTitle();
         if (isAnalysisUpToDate()) {
           // This should not be stale data when the command number match
           if (isKataGo) {
@@ -404,6 +396,14 @@ public class Leelaz {
         isThinking = false;
 
       } else if (line.startsWith("=") || line.startsWith("?")) {
+        if (!isLoaded) {
+          isLoaded = true;
+          // Clear switching prompt
+          switching = false;
+          // Display engine command in the title
+          Lizzie.frame.updateTitle();
+          Lizzie.frame.refresh();
+        }
         if (printCommunication || gtpConsole) {
           System.out.print(line);
           Lizzie.gtpConsole.addLine(line);

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -1247,6 +1247,7 @@ public class Menu extends JMenuBar {
               Lizzie.leelaz.isThinking = false;
             }
             Lizzie.leelaz.togglePonder();
+            Lizzie.frame.refresh();
           }
         });
     analyzeMenu.add(toggleAnalyze);


### PR DESCRIPTION
Fix the following issues.

Issue A:
Hit the space key while "Engine is loading..." is displayed. Then this message remains even when loading is finished actually.

Issue B:
Switch the engine from the menu and never move the mouse after the click. Then "Engine is loading..." is never shown until you move the mouse.
