### PR TITLE
Quick hack to support #785 (<nickname> before the engine command)

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -78,6 +78,7 @@ public class Leelaz {
 
   // for Multiple Engine
   private String engineCommand;
+  private String engineNickname;
   private List<String> commands;
   private JSONObject config;
   private String currentWeightFile = "";
@@ -128,6 +129,14 @@ public class Leelaz {
       // substitute in the weights file
       engineCommand = engineCommand.replaceAll("%network-file", config.getString("network-file"));
     }
+    Matcher nicknameMatcher = Pattern.compile("<([^<]*)>\\s*(.*)").matcher(engineCommand);
+    if (nicknameMatcher.matches()) {
+      engineNickname = nicknameMatcher.group(1);
+      engineCommand = nicknameMatcher.group(2);
+    } else {
+      engineNickname = null;
+    }
+
     this.engineCommand = engineCommand;
     if (engineCommand.toLowerCase().contains("override-version")) {
       this.isKataGo = true;
@@ -985,6 +994,10 @@ public class Leelaz {
 
   public boolean supportScoremean() {
     return isKataGo || supportScoremean;
+  }
+
+  public String nicknameOrcurrentWeight() {
+    return (engineNickname == null) ? currentWeight : engineNickname;
   }
 
   public String currentWeight() {

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -996,7 +996,7 @@ public class Leelaz {
     return isKataGo || supportScoremean;
   }
 
-  public String nicknameOrcurrentWeight() {
+  public String nicknameOrCurrentWeight() {
     return (engineNickname == null) ? currentWeight : engineNickname;
   }
 

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -1024,6 +1024,10 @@ public class Leelaz {
     return currentEngineN;
   }
 
+  public String nicknameOrEngineCommand() {
+    return (engineNickname == null) ? engineCommand : engineNickname;
+  }
+
   public String engineCommand() {
     return this.engineCommand;
   }

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -129,15 +129,8 @@ public class Leelaz {
       // substitute in the weights file
       engineCommand = engineCommand.replaceAll("%network-file", config.getString("network-file"));
     }
-    Matcher nicknameMatcher = Pattern.compile("<([^<]*)>\\s*(.*)").matcher(engineCommand);
-    if (nicknameMatcher.matches()) {
-      engineNickname = nicknameMatcher.group(1);
-      engineCommand = nicknameMatcher.group(2);
-    } else {
-      engineNickname = null;
-    }
-
-    this.engineCommand = engineCommand;
+    updateEngineCommandAndNickname(engineCommand);
+    engineCommand = this.engineCommand;
     if (engineCommand.toLowerCase().contains("override-version")) {
       this.isKataGo = true;
     }
@@ -955,7 +948,8 @@ public class Leelaz {
   }
 
   public boolean isCommandChange(String command) {
-    List<String> newList = splitCommand(command);
+    updateEngineCommandAndNickname(command);
+    List<String> newList = splitCommand(engineCommand);
     if (this.commands.size() != newList.size()) {
       engineIndex++;
       return true;
@@ -970,6 +964,17 @@ public class Leelaz {
         }
       }
       return false;
+    }
+  }
+
+  private void updateEngineCommandAndNickname(String command) {
+    Matcher nicknameMatcher = Pattern.compile("<(.*?)>\\s*(.*)").matcher(command);
+    if (nicknameMatcher.matches()) {
+      engineNickname = nicknameMatcher.group(1);
+      engineCommand = nicknameMatcher.group(2);
+    } else {
+      engineNickname = null;
+      engineCommand = command;
     }
   }
 

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -761,6 +761,9 @@ public class ConfigDialog extends JDialog {
                     txts[i].setText(a.getString(i));
                   });
         });
+    Arrays.asList(txts)
+        .stream()
+        .forEach(t -> t.setToolTipText("Engine Command or <Label> Engine Command"));
 
     chkPreloads =
         new JCheckBox[] {

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -119,17 +119,17 @@ public class ConfigDialog extends JDialog {
   public JButton okButton;
 
   // Engine Tab
-  private JTextField txtEngine;
-  private JTextField txtEngine1;
-  private JTextField txtEngine2;
-  private JTextField txtEngine3;
-  private JTextField txtEngine4;
-  private JTextField txtEngine5;
-  private JTextField txtEngine6;
-  private JTextField txtEngine7;
-  private JTextField txtEngine8;
-  private JTextField txtEngine9;
-  private JTextField[] txts;
+  private LeftTextField txtEngine;
+  private LeftTextField txtEngine1;
+  private LeftTextField txtEngine2;
+  private LeftTextField txtEngine3;
+  private LeftTextField txtEngine4;
+  private LeftTextField txtEngine5;
+  private LeftTextField txtEngine6;
+  private LeftTextField txtEngine7;
+  private LeftTextField txtEngine8;
+  private LeftTextField txtEngine9;
+  private LeftTextField[] txts;
   private JCheckBox chkPreload1;
   private JCheckBox chkPreload2;
   private JCheckBox chkPreload3;
@@ -270,7 +270,7 @@ public class ConfigDialog extends JDialog {
     lblEngine.setHorizontalAlignment(SwingConstants.LEFT);
     engineTab.add(lblEngine);
 
-    txtEngine = new JTextField();
+    txtEngine = new LeftTextField();
     txtEngine.setBounds(87, 40, 481, 26);
     engineTab.add(txtEngine);
     txtEngine.setColumns(10);
@@ -285,7 +285,7 @@ public class ConfigDialog extends JDialog {
     lblEngine1.setBounds(6, 80, 92, 16);
     engineTab.add(lblEngine1);
 
-    txtEngine2 = new JTextField();
+    txtEngine2 = new LeftTextField();
     txtEngine2.setColumns(10);
     txtEngine2.setBounds(87, 105, 481, 26);
     engineTab.add(txtEngine2);
@@ -298,7 +298,7 @@ public class ConfigDialog extends JDialog {
     lblEngine2.setBounds(6, 110, 92, 16);
     engineTab.add(lblEngine2);
 
-    txtEngine1 = new JTextField();
+    txtEngine1 = new LeftTextField();
     txtEngine1.setColumns(10);
     txtEngine1.setBounds(87, 75, 481, 26);
     engineTab.add(txtEngine1);
@@ -311,7 +311,7 @@ public class ConfigDialog extends JDialog {
     lblEngine3.setBounds(6, 140, 92, 16);
     engineTab.add(lblEngine3);
 
-    txtEngine3 = new JTextField();
+    txtEngine3 = new LeftTextField();
     txtEngine3.setColumns(10);
     txtEngine3.setBounds(87, 135, 481, 26);
     engineTab.add(txtEngine3);
@@ -324,7 +324,7 @@ public class ConfigDialog extends JDialog {
     lblEngine4.setBounds(6, 170, 92, 16);
     engineTab.add(lblEngine4);
 
-    txtEngine4 = new JTextField();
+    txtEngine4 = new LeftTextField();
     txtEngine4.setColumns(10);
     txtEngine4.setBounds(87, 165, 481, 26);
     engineTab.add(txtEngine4);
@@ -337,7 +337,7 @@ public class ConfigDialog extends JDialog {
     lblEngine5.setBounds(6, 200, 92, 16);
     engineTab.add(lblEngine5);
 
-    txtEngine5 = new JTextField();
+    txtEngine5 = new LeftTextField();
     txtEngine5.setColumns(10);
     txtEngine5.setBounds(87, 195, 481, 26);
     engineTab.add(txtEngine5);
@@ -350,7 +350,7 @@ public class ConfigDialog extends JDialog {
     lblEngine6.setBounds(6, 230, 92, 16);
     engineTab.add(lblEngine6);
 
-    txtEngine6 = new JTextField();
+    txtEngine6 = new LeftTextField();
     txtEngine6.setColumns(10);
     txtEngine6.setBounds(87, 225, 481, 26);
     engineTab.add(txtEngine6);
@@ -363,7 +363,7 @@ public class ConfigDialog extends JDialog {
     lblEngine7.setBounds(6, 260, 92, 16);
     engineTab.add(lblEngine7);
 
-    txtEngine7 = new JTextField();
+    txtEngine7 = new LeftTextField();
     txtEngine7.setColumns(10);
     txtEngine7.setBounds(87, 255, 481, 26);
     engineTab.add(txtEngine7);
@@ -376,7 +376,7 @@ public class ConfigDialog extends JDialog {
     lblEngine8.setBounds(6, 290, 92, 16);
     engineTab.add(lblEngine8);
 
-    txtEngine8 = new JTextField();
+    txtEngine8 = new LeftTextField();
     txtEngine8.setColumns(10);
     txtEngine8.setBounds(87, 285, 481, 26);
     engineTab.add(txtEngine8);
@@ -384,7 +384,7 @@ public class ConfigDialog extends JDialog {
     chkPreload8.setBounds(570, 286, 23, 23);
     engineTab.add(chkPreload8);
 
-    txtEngine9 = new JTextField();
+    txtEngine9 = new LeftTextField();
     txtEngine9.setColumns(10);
     txtEngine9.setBounds(87, 315, 481, 26);
     engineTab.add(txtEngine9);
@@ -738,7 +738,7 @@ public class ConfigDialog extends JDialog {
 
     // Engines
     txts =
-        new JTextField[] {
+        new LeftTextField[] {
           txtEngine1,
           txtEngine2,
           txtEngine3,

--- a/src/main/java/featurecat/lizzie/gui/LeftTextField.java
+++ b/src/main/java/featurecat/lizzie/gui/LeftTextField.java
@@ -1,0 +1,13 @@
+package featurecat.lizzie.gui;
+
+import javax.swing.JTextField;
+
+// Ensure that the beginning of long text is visible after setText.
+
+public class LeftTextField extends JTextField {
+
+  public void setText(String t) {
+    super.setText(t);
+    setCaretPosition(0);
+  }
+}

--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -163,8 +163,8 @@ public abstract class MainFrame extends JFrame {
   public void updateTitle() {
     StringBuilder sb = new StringBuilder(DEFAULT_TITLE);
     sb.append(playerTitle);
-    sb.append(" [" + Lizzie.leelaz.nicknameOrEngineCommand() + "]");
     sb.append(visitsString);
+    sb.append(" [" + Lizzie.leelaz.nicknameOrEngineCommand() + "]");
     setTitle(sb.toString());
   }
 

--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -163,7 +163,7 @@ public abstract class MainFrame extends JFrame {
   public void updateTitle() {
     StringBuilder sb = new StringBuilder(DEFAULT_TITLE);
     sb.append(playerTitle);
-    sb.append(" [" + Lizzie.leelaz.engineCommand() + "]");
+    sb.append(" [" + Lizzie.leelaz.nicknameOrEngineCommand() + "]");
     sb.append(visitsString);
     setTitle(sb.toString());
   }

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -1384,8 +1384,8 @@ public class Menu extends JMenuBar {
       engine[i].setVisible(false);
       Leelaz engineDt = engineList.get(i);
       if (engineDt != null) {
-        if (engineDt.currentWeight() != "")
-          engine[i].setText(engine[i].getText() + " : " + engineDt.nicknameOrcurrentWeight());
+        if (engineDt.nicknameOrCurrentWeight() != "")
+          engine[i].setText(engine[i].getText() + " : " + engineDt.nicknameOrCurrentWeight());
         engine[i].setVisible(true);
         int a = i;
         engine[i].addActionListener(

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -1385,7 +1385,7 @@ public class Menu extends JMenuBar {
       Leelaz engineDt = engineList.get(i);
       if (engineDt != null) {
         if (engineDt.currentWeight() != "")
-          engine[i].setText(engine[i].getText() + " : " + engineDt.currentWeight());
+          engine[i].setText(engine[i].getText() + " : " + engineDt.nicknameOrcurrentWeight());
         engine[i].setVisible(true);
         int a = i;
         engine[i].addActionListener(


### PR DESCRIPTION
You can write `<foo> ./leelaz -g -w network.gz` in the menu Settings > Engine for example. Then `foo` is used as the label in the engine menu and `./leelaz -g -w network.gz` is used as the actual engine command.

This is just a quick hack to support #785. It is not a good way. But it seems to be desired strongly by some people ([ref.](https://github.com/featurecat/lizzie/issues/671#issuecomment-640103271)).
