### PR TITLE
Fix missing mark and color in the variation tree

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieMain.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieMain.java
@@ -510,6 +510,8 @@ public class LizzieMain extends MainFrame {
       invalidLayout();
     } else {
       boardPane.repaint();
+      //    variationTreePane.revalidate();
+      variationTreePane.repaint();
       if (type != 1) {
         updateStatus();
       }
@@ -537,8 +539,6 @@ public class LizzieMain extends MainFrame {
         variationTreePane.setVisible(true);
       }
     }
-    //    variationTreePane.revalidate();
-    variationTreePane.repaint();
     commentPane.drawComment();
     //    commentPane.revalidate();
     commentPane.repaint();

--- a/src/main/java/featurecat/lizzie/gui/VariationTree.java
+++ b/src/main/java/featurecat/lizzie/gui/VariationTree.java
@@ -132,18 +132,18 @@ public class VariationTree {
           }
           g.setColor(Utils.getBlunderNodeColor(cur));
           g.fillOval(curposx + diff, posy + diff, diam, diam);
-          if (startNode == curMove) {
-            g.setColor(Color.BLACK);
-            g.fillOval(
-                curposx + (DOT_DIAM + diff - CENTER_DIAM) / 2,
-                posy + (DOT_DIAM + diff - CENTER_DIAM) / 2,
-                CENTER_DIAM,
-                CENTER_DIAM);
-          }
         } else {
           g.fillRect(curposx, posy, DOT_DIAM, DOT_DIAM);
           g.setColor(Color.BLACK);
           g.drawRect(curposx, posy, DOT_DIAM, DOT_DIAM);
+        }
+        if (startNode == curMove) {
+          g.setColor(Color.BLACK);
+          g.fillOval(
+              curposx + (DOT_DIAM + diff - CENTER_DIAM) / 2,
+              posy + (DOT_DIAM + diff - CENTER_DIAM) / 2,
+              CENTER_DIAM,
+              CENTER_DIAM);
         }
       }
       g.setColor(curcolor);

--- a/src/main/java/featurecat/lizzie/util/Utils.java
+++ b/src/main/java/featurecat/lizzie/util/Utils.java
@@ -127,6 +127,10 @@ public class Utils {
       Leelaz.WinrateStats stats = Lizzie.leelaz.getWinrateStats();
       curWR = stats.maxWinrate;
       validWinrate = (stats.totalPlayouts > 0);
+      if (!validWinrate && (data.getPlayouts() > 0)) {
+        validWinrate = true;
+        curWR = data.winrate;
+      }
       if (Lizzie.frame.isPlayingAgainstLeelaz
           && Lizzie.frame.playerIsBlack == !Lizzie.board.getHistory().getData().blackToPlay) {
         validWinrate = false;


### PR DESCRIPTION
This PR fixes two issues on the variation tree.

(1) The current node mark (black dot) is missing when we are at the root node (= the empty board).

(2) The blunder color of the current node is missing...

* (Normal UI) ...when pondering is off.
* (Panel UI) ...until we turn pondering off.
