### PR TITLE
Fix #423 (node blunder colors in the default theme)

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -199,16 +199,14 @@ public class Config {
     if (alreadyTriedOnce) return false;
 
     boolean modified = false;
-    String theme = ui.optString("theme", "");
     JSONArray blunderWinrateThresholds = ui.optJSONArray("blunder-winrate-thresholds");
     JSONArray blunderNodeColors = ui.optJSONArray("blunder-node-colors");
-    boolean isDefaultTheme = theme.toLowerCase().equals("default");
     boolean isEmptyBlunderWinrateThresholds =
         (blunderWinrateThresholds == null || blunderWinrateThresholds.length() == 0);
     boolean isEmptyBlunderNodeColors =
         (blunderNodeColors == null || blunderNodeColors.length() == 0);
 
-    if (isDefaultTheme && isEmptyBlunderWinrateThresholds && isEmptyBlunderNodeColors) {
+    if (isEmptyBlunderWinrateThresholds && isEmptyBlunderNodeColors) {
       // https://github.com/featurecat/lizzie/issues/423#issuecomment-438878060
       ui.put("blunder-winrate-thresholds", new JSONArray("[-30, -20, -10.1, -5.1, 5, 10.1]"));
       ui.put(

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -202,7 +202,7 @@ public class Config {
     String theme = ui.optString("theme", "");
     JSONArray blunderWinrateThresholds = ui.optJSONArray("blunder-winrate-thresholds");
     JSONArray blunderNodeColors = ui.optJSONArray("blunder-node-colors");
-    boolean isDefaultTheme = theme.equals("Default");
+    boolean isDefaultTheme = theme.toLowerCase().equals("default");
     boolean isEmptyBlunderWinrateThresholds =
         (blunderWinrateThresholds == null || blunderWinrateThresholds.length() == 0);
     boolean isEmptyBlunderNodeColors =

--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -179,17 +179,58 @@ public class Config {
       madeCorrections = true;
     }
 
+    if (checkEmptyBlunderThresholds(ui)) {
+      madeCorrections = true;
+    }
+
     return madeCorrections;
+  }
+
+  /**
+   * Apply the default blunder thresholds in Default theme if they are empty. This works only once
+   * as the fix of #423 (missing default thresholds) so that users can set them empty again if they
+   * like.
+   *
+   * @param ui The UI config json object to check
+   * @return if any correction has been made.
+   */
+  private boolean checkEmptyBlunderThresholds(JSONObject ui) {
+    boolean alreadyTriedOnce = persisted.optBoolean("checked-empty-blunder-thresholds", false);
+    if (alreadyTriedOnce) return false;
+
+    boolean modified = false;
+    String theme = ui.optString("theme", "");
+    JSONArray blunderWinrateThresholds = ui.optJSONArray("blunder-winrate-thresholds");
+    JSONArray blunderNodeColors = ui.optJSONArray("blunder-node-colors");
+    boolean isDefaultTheme = theme.equals("Default");
+    boolean isEmptyBlunderWinrateThresholds =
+        (blunderWinrateThresholds == null || blunderWinrateThresholds.length() == 0);
+    boolean isEmptyBlunderNodeColors =
+        (blunderNodeColors == null || blunderNodeColors.length() == 0);
+
+    if (isDefaultTheme && isEmptyBlunderWinrateThresholds && isEmptyBlunderNodeColors) {
+      // https://github.com/featurecat/lizzie/issues/423#issuecomment-438878060
+      ui.put("blunder-winrate-thresholds", new JSONArray("[-30, -20, -10.1, -5.1, 5, 10.1]"));
+      ui.put(
+          "blunder-node-colors",
+          new JSONArray(
+              "[[255, 0, 0], [255, 120, 0], [255, 200, 0], [255, 255, 0], [150, 255, 0], [0, 255, 0]]"));
+      modified = true;
+    }
+
+    persisted.put("checked-empty-blunder-thresholds", true);
+    return modified;
   }
 
   public Config() throws IOException {
     JSONObject defaultConfig = createDefaultConfig();
     JSONObject persistConfig = createPersistConfig();
 
-    // Main properties
-    this.config = loadAndMergeConfig(defaultConfig, configFilename, true);
+    // Load "persisted" before "config" for checkEmptyBlunderThresholds.
     // Persisted properties
     this.persisted = loadAndMergeConfig(persistConfig, persistFilename, false);
+    // Main properties
+    this.config = loadAndMergeConfig(defaultConfig, configFilename, true);
 
     leelazConfig = config.getJSONObject("leelaz");
     uiConfig = config.getJSONObject("ui");


### PR DESCRIPTION
I'm afraid most users may not notice the feature #413 because of the issue #423. This PR applies the proposed parameters in https://github.com/featurecat/lizzie/issues/423#issuecomment-438878060 if they are empty. It works only once so that users can still set them empty again if they like.

related: #800 #801
