### PR TITLE
Fix #781 (slow play/undo/redo)

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieMain.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieMain.java
@@ -542,7 +542,6 @@ public class LizzieMain extends MainFrame {
     commentPane.drawComment();
     //    commentPane.revalidate();
     commentPane.repaint();
-    invalidLayout();
   }
 
   @Override

--- a/src/main/java/featurecat/lizzie/gui/LizzieMain.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieMain.java
@@ -122,6 +122,11 @@ public class LizzieMain extends MainFrame {
               }
               // draw the image
               Graphics2D bsGraphics = (Graphics2D) g; // bs.getDrawGraphics();
+              // Note: #781 is caused by repaint of other parts (toolBar in particular) with
+              // VALUE_ANTIALIAS_ON. To prevent such unwilling side effects, we change
+              // RenderingHints only temporary here and restore their old values at the bottom of
+              // this method.
+              RenderingHints oldHints = bsGraphics.getRenderingHints();
               bsGraphics.setRenderingHint(
                   RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
               bsGraphics.setRenderingHint(
@@ -172,6 +177,7 @@ public class LizzieMain extends MainFrame {
               } else if (Lizzie.config.showStatus) {
                 drawPonderingState(bsGraphics, loadingText(), loadingX, loadingY, loadingSize);
               }
+              bsGraphics.setRenderingHints(oldHints);
             }
           }
         };

--- a/src/main/java/featurecat/lizzie/gui/LizzieMain.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieMain.java
@@ -542,6 +542,7 @@ public class LizzieMain extends MainFrame {
     commentPane.drawComment();
     //    commentPane.revalidate();
     commentPane.repaint();
+    invalidLayout();
   }
 
   @Override


### PR DESCRIPTION
In Panel UI, the layouts of all the UI parts are rearranged in every play/undo/redo after d2c587cdb. #781 seems to be fixed if we stop this redundant work. Can anybody test this PR for a week or so and report whether you notice any problem?
