### PR TITLE
Fix #805(The ">>" doesn't work properly)

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/ToolBar.java
+++ b/src/main/java/featurecat/lizzie/gui/ToolBar.java
@@ -212,7 +212,7 @@ public class ToolBar extends JToolBar {
     forward10.addActionListener(
         new ActionListener() {
           public void actionPerformed(ActionEvent e) {
-            Input.redo(1);
+            Input.redo(10);
           }
         });
     add(forward10);


### PR DESCRIPTION
fix #805  
The ">>" on the lower toolbar is originally a function that "advance 10 moves", but there was a bug that only one move was actually made.
It seems that there was a mistake in specifying the number, so I corrected it.
