### PR TITLE
Fix: Remove wrong-sized ownership marks

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -263,6 +263,8 @@ public class BoardRenderer {
 
       cachedShadow = null;
       cachedGhostShadow = null;
+      cachedEstimateLargeRectImage = emptyImage;
+      cachedEstimateSmallRectImage = emptyImage;
 
       cachedBackgroundImage = new BufferedImage(width, height, TYPE_INT_ARGB);
       Graphics2D g = cachedBackgroundImage.createGraphics();


### PR DESCRIPTION
This PR removes wrong-sized ownership marks after resizing of the window when pondering is off.

I give up redrawing of them as it requires additional code. (Note: In 0.7.4, the following code is written directly in parseLine() in Leelaz.java.)

~~~
            if (Lizzie.config.showKataGoEstimate) {
              if (line.contains("ownership")) {
                estimateArray = new ArrayList<Double>();
                String[] params = line.trim().split("ownership");
                String[] params2 = params[1].trim().split(" ");
                for (int i = 0; i < params2.length; i++) {
                  estimateArray.add(Double.parseDouble(params2[i]));
                }
                Lizzie.frame.drawEstimateRectKata(estimateArray);
              }
            }
~~~
