### PR TITLE
Fix "up arrow" key in Panel UI

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieMain.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieMain.java
@@ -765,6 +765,7 @@ public class LizzieMain extends MainFrame {
   public void clearBeforeMove() {
     // TODO Auto-generated method stub
     subBoardPane.clearBeforeMove();
+    Lizzie.frame.isMouseOver = false;
     if (Lizzie.frame.isEstimating) {
       Lizzie.frame.noEstimateByZen(false);
     }


### PR DESCRIPTION
1. Start Lizzie 0.7.4 in Panel UI.
2. Click a suggested move and never touch the mouse afterward.
3. Hit Up arrow key.

Then I expect an empty board. But the placed stone is still shown actually. #556 (4c74cdc7e) may be related to this issue.
