### PR TITLE
Show background playouts

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -252,11 +252,18 @@ public class LizzieFrame extends MainFrame {
             if (Lizzie.leelaz == null) return;
             try {
               int totalPlayouts = MoveData.getPlayouts(Lizzie.leelaz.getBestMoves());
-              if (totalPlayouts <= 0) return;
+              int recorderTotalPlayouts = Lizzie.board.getData().getPlayouts();
+              int displayedTotalPlayouts = Math.max(totalPlayouts, recorderTotalPlayouts);
+              if (displayedTotalPlayouts <= 0) return;
+              boolean showingRecorded =
+                  (totalPlayouts < displayedTotalPlayouts) && (totalPlayouts > 0);
+              String backgroundTotalPlayoutsString =
+                  showingRecorded ? String.format("%d/", totalPlayouts) : "";
               visitsString =
                   String.format(
-                      " %d playouts, %d visits/second",
-                      totalPlayouts,
+                      " %s%d playouts, %d visits/second",
+                      backgroundTotalPlayoutsString,
+                      displayedTotalPlayouts,
                       (totalPlayouts > lastPlayouts) ? totalPlayouts - lastPlayouts : 0);
               updateTitle();
               lastPlayouts = totalPlayouts;

--- a/src/main/java/featurecat/lizzie/gui/LizzieMain.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieMain.java
@@ -279,11 +279,18 @@ public class LizzieMain extends MainFrame {
             if (Lizzie.leelaz == null) return;
             try {
               int totalPlayouts = MoveData.getPlayouts(Lizzie.leelaz.getBestMoves());
-              if (totalPlayouts <= 0) return;
+              int recorderTotalPlayouts = Lizzie.board.getData().getPlayouts();
+              int displayedTotalPlayouts = Math.max(totalPlayouts, recorderTotalPlayouts);
+              if (displayedTotalPlayouts <= 0) return;
+              boolean showingRecorded =
+                  (totalPlayouts < displayedTotalPlayouts) && (totalPlayouts > 0);
+              String backgroundTotalPlayoutsString =
+                  showingRecorded ? String.format("%d/", totalPlayouts) : "";
               visitsString =
                   String.format(
-                      " %d playouts, %d visits/second",
-                      totalPlayouts,
+                      " %s%d playouts, %d visits/second",
+                      backgroundTotalPlayoutsString,
+                      displayedTotalPlayouts,
                       (totalPlayouts > lastPlayouts) ? totalPlayouts - lastPlayouts : 0);
               updateTitle();
               lastPlayouts = totalPlayouts;


### PR DESCRIPTION
Show the background playouts in the title bar for convenience (e.g. debugging of #820) if a recorded analysis is displayed. Note that you also need to apply #794.
