### PR TITLE
Revive score mode

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1498,6 +1498,10 @@ public class LizzieFrame extends MainFrame {
     if (byToolBar) countResults.setVisible(false);
   }
 
+  public void updateScoreMenu(boolean on) {
+    menu.updateScoreMenu(on);
+  }
+
   public void updateEngineMenu(List<Leelaz> engineList) {
     menu.updateEngineMenu(engineList);
   }

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1498,10 +1498,6 @@ public class LizzieFrame extends MainFrame {
     if (byToolBar) countResults.setVisible(false);
   }
 
-  public void updateScoreMenu(boolean on) {
-    menu.updateScoreMenu(on);
-  }
-
   public void updateEngineMenu(List<Leelaz> engineList) {
     menu.updateEngineMenu(engineList);
   }
@@ -1512,6 +1508,10 @@ public class LizzieFrame extends MainFrame {
 
   public Optional<int[]> convertScreenToCoordinates(int x, int y) {
     return boardRenderer.convertScreenToCoordinates(x, y);
+  }
+
+  public void updateScoreMenu(boolean on) {
+    menu.updateScoreMenu(on);
   }
 
   public boolean openRightClickMenu(int x, int y) {

--- a/src/main/java/featurecat/lizzie/gui/LizzieMain.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieMain.java
@@ -714,6 +714,10 @@ public class LizzieMain extends MainFrame {
     boardPane.saveImage();
   };
 
+  public void updateScoreMenu(boolean on) {
+    menu.updateScoreMenu(on);
+  }
+
   public void updateEngineMenu(List<Leelaz> engineList) {
     menu.updateEngineMenu(engineList);
   }

--- a/src/main/java/featurecat/lizzie/gui/LizzieMain.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieMain.java
@@ -714,10 +714,6 @@ public class LizzieMain extends MainFrame {
     boardPane.saveImage();
   };
 
-  public void updateScoreMenu(boolean on) {
-    menu.updateScoreMenu(on);
-  }
-
   public void updateEngineMenu(List<Leelaz> engineList) {
     menu.updateEngineMenu(engineList);
   }
@@ -728,6 +724,10 @@ public class LizzieMain extends MainFrame {
 
   public Optional<int[]> convertScreenToCoordinates(int x, int y) {
     return boardPane.convertScreenToCoordinates(x, y);
+  }
+
+  public void updateScoreMenu(boolean on) {
+    menu.updateScoreMenu(on);
   }
 
   public boolean openRightClickMenu(int x, int y) {

--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -386,13 +386,13 @@ public abstract class MainFrame extends JFrame {
 
   public void saveImage() {};
 
-  public abstract void updateScoreMenu(boolean on);
-
   public abstract void updateEngineMenu(List<Leelaz> engineList);
 
   public abstract void updateEngineIcon(List<Leelaz> engineList, int currentEngineNo);
 
   public abstract Optional<int[]> convertScreenToCoordinates(int x, int y);
+
+  public abstract void updateScoreMenu(boolean on);
 
   public abstract boolean openRightClickMenu(int x, int y);
 

--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -386,6 +386,8 @@ public abstract class MainFrame extends JFrame {
 
   public void saveImage() {};
 
+  public abstract void updateScoreMenu(boolean on);
+
   public abstract void updateEngineMenu(List<Leelaz> engineList);
 
   public abstract void updateEngineIcon(List<Leelaz> engineList, int currentEngineNo);

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -1233,6 +1233,19 @@ public class Menu extends JMenuBar {
         });
     gameMenu.add(gotoRight);
 
+    gameMenu.addSeparator();
+
+    final JCheckBoxMenuItem scoreMode = new JCheckBoxMenuItem("Score game");
+    gameMenu.add(scoreMode);
+    scoreMode.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            Lizzie.board.setScoreMode(scoreMode.isSelected());
+            Lizzie.frame.repaint();
+          }
+        });
+
     final JMenu analyzeMenu = new JMenu(resourceBundle.getString("Menu.analyze"));
     this.add(analyzeMenu);
 

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -22,6 +22,7 @@ public class Menu extends JMenuBar {
   public static ImageIcon ready;
   public static JMenuItem[] engine;
   public static JMenu engineMenu;
+  private static JCheckBoxMenuItem scoreMode;
   private static final ResourceBundle resourceBundle = MainFrame.resourceBundle;
 
   public Menu() {
@@ -1235,7 +1236,7 @@ public class Menu extends JMenuBar {
 
     gameMenu.addSeparator();
 
-    final JCheckBoxMenuItem scoreMode = new JCheckBoxMenuItem("Score game");
+    scoreMode = new JCheckBoxMenuItem("Score game");
     gameMenu.add(scoreMode);
     scoreMode.addActionListener(
         new ActionListener() {
@@ -1385,6 +1386,10 @@ public class Menu extends JMenuBar {
       // TODO Auto-generated catch block
       e.printStackTrace();
     }
+  }
+
+  public void updateScoreMenu(boolean on) {
+    scoreMode.setSelected(on);
   }
 
   public void updateEngineMenu(List<Leelaz> engineList) {

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -1147,6 +1147,7 @@ public class Board implements LeelazListener {
       capturedStones = new Stone[] {};
     }
     scoreMode = on;
+    Lizzie.frame.updateScoreMenu(on);
   }
 
   /*

--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -1140,6 +1140,9 @@ public class Board implements LeelazListener {
   }
 
   public void setScoreMode(boolean on) {
+    if (history.getMoveNumber() == 0) {
+      on = false;
+    }
     if (on) {
       // load a copy of the data at the current node of history
       capturedStones = history.getStones().clone();


### PR DESCRIPTION
This PR revives score mode #170 by @bittsitt, that has been disabled after #558.

Usage:

1. Play a game to the end.
2. Select the menu Game > Score game to enter score mode.
3. Click to remove dead stones. (Click again to cancel.)
4. The scores are shown instead of the captured stones above the winrate bar.
5. Select the menu Game > Score game again to leave score mode.
