### PR TITLE
Switch rules from the menu

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -59,6 +59,7 @@ public class Config {
   public boolean showKataGoEstimateOnMainboard = true;
   public String kataGoEstimateMode = "small+dead";
   public boolean kataGoEstimateBlend = true;
+  public String kataGoRule = "tromp-taylor";
 
   public boolean showStatus = true;
   public boolean showBranch = true;
@@ -245,6 +246,7 @@ public class Config {
     showKataGoEstimateOnMainboard = uiConfig.optBoolean("show-katago-estimate-onmainboard", true);
     kataGoEstimateMode = uiConfig.optString("katago-estimate-mode", "small+dead");
     kataGoEstimateBlend = uiConfig.optBoolean("katago-estimate-blend", true);
+    kataGoRule = uiConfig.optString("katago-rule", "tromp-taylor");
     showWinrateInSuggestion = uiConfig.optBoolean("show-winrate-in-suggestion", true);
     showPlayoutsInSuggestion = uiConfig.optBoolean("show-playouts-in-suggestion", true);
     showScoremeanInSuggestion = uiConfig.optBoolean("show-scoremean-in-suggestion", true);
@@ -423,6 +425,11 @@ public class Config {
     uiConfig.put("katago-estimate-blend", kataGoEstimateBlend);
   }
 
+  public void setKataGoRule(String rule) {
+    kataGoRule = rule;
+    uiConfig.put("katago-rule", kataGoRule);
+  }
+
   public void toggleShowStatus() {
     this.showStatus = !this.showStatus;
     Lizzie.config.uiConfig.put("show-status", showStatus);
@@ -556,6 +563,7 @@ public class Config {
     ui.put("show-katago-estimate-onmainboard", true);
     ui.put("katago-estimate-mode", "small");
     ui.put("katago-estimate-blend", true);
+    ui.put("katago-rule", "tromp-taylor");
     config.put("ui", ui);
     return config;
   }

--- a/src/main/java/featurecat/lizzie/Lizzie.java
+++ b/src/main/java/featurecat/lizzie/Lizzie.java
@@ -51,6 +51,7 @@ public class Lizzie {
   }
 
   public static void initializeAfterVersionCheck(Leelaz lz) {
+    lz.updateKataGoRule();
     if (config.handicapInsteadOfWinrate) {
       lz.estimatePassWinrate();
     }

--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -117,6 +117,7 @@ public class EngineManager {
       if (!newEng.isStarted()) {
         newEng.startEngine();
       } else {
+        newEng.updateKataGoRule();
         if (!newEng.isPondering()) {
           newEng.togglePonder();
         }

--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -1024,6 +1024,16 @@ public class Leelaz {
     }
   }
 
+  public void updateKataGoRule() {
+    updateKataGoRule(false);
+  }
+
+  public void updateKataGoRule(boolean keepPondering) {
+    if (!isKataGo) return;
+    sendCommand("kata-set-rules " + Lizzie.config.kataGoRule);
+    if (isPondering && keepPondering) ponder();
+  }
+
   // Writer thread for avoiding deadlock (#752)
   class WriterThread extends Thread {
     public ArrayDeque<String> writerQueue = new ArrayDeque<>();

--- a/src/main/java/featurecat/lizzie/gui/BasicInfoPane.java
+++ b/src/main/java/featurecat/lizzie/gui/BasicInfoPane.java
@@ -173,6 +173,13 @@ public class BasicInfoPane extends LizziePane {
     g.drawString(bTime, posX + width / 10, posY + height / 6);
     g.drawString(wTime, posX + width * 3 / 5, posY + height / 6);
 
+    // Rule
+    if (Lizzie.leelaz.isKataGo) {
+      String rule = Lizzie.config.kataGoRule;
+      int rw = g.getFontMetrics().stringWidth(rule);
+      g.drawString(rule, posX - strokeRadius + width / 2 - rw / 2, posY + height * 5 / 16);
+    }
+
     // Komi
     String komi =
         GameInfoDialog.FORMAT_KOMI.format(Lizzie.board.getHistory().getGameInfo().getKomi());

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -24,6 +24,21 @@ public class Menu extends JMenuBar {
   public static JMenu engineMenu;
   private static final ResourceBundle resourceBundle = MainFrame.resourceBundle;
 
+  private static JMenu kataGoRuleMenu;
+  private static final String[] kataGoRuleNames = {
+    "tromp-taylor",
+    "chinese",
+    "chinese-ogs",
+    "chinese-kgs",
+    "japanese",
+    "korean",
+    "stone-scoring",
+    "aga",
+    "bga",
+    "new-zealand",
+    "aga-button",
+  };
+
   public Menu() {
     setBorder(new EmptyBorder(0, 0, 0, 0));
     final JMenu fileMenu = new JMenu(resourceBundle.getString("Menu.file"));
@@ -1294,6 +1309,34 @@ public class Menu extends JMenuBar {
         });
     analyzeMenu.add(estimate);
 
+    kataGoRuleMenu = new JMenu("Rule");
+    kataGoRuleMenu.setEnabled(false);
+    analyzeMenu.add(kataGoRuleMenu);
+
+    final ButtonGroup kataGoRuleGroup = new ButtonGroup();
+
+    for (String rule : kataGoRuleNames) {
+      boolean selected = rule.equals(Lizzie.config.kataGoRule);
+      JRadioButtonMenuItem item = new JRadioButtonMenuItem(rule, selected);
+      item.addActionListener(
+          new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+              if (rule.equals(Lizzie.config.kataGoRule)) return;
+              Lizzie.config.setKataGoRule(rule);
+              Lizzie.leelaz.updateKataGoRule(true);
+              Lizzie.board.clearAnalysis();
+              try {
+                Lizzie.config.save();
+              } catch (IOException es) {
+                // TODO Auto-generated catch block
+              }
+            }
+          });
+      kataGoRuleGroup.add(item);
+      kataGoRuleMenu.add(item);
+    }
+
     analyzeMenu.addMenuListener(
         new MenuListener() {
           public void menuSelected(MenuEvent e) {
@@ -1407,6 +1450,7 @@ public class Menu extends JMenuBar {
             if (i == currentEngineNo) {
               engine[i].setIcon(running);
               engineMenu.setText(engine[i].getText());
+              kataGoRuleMenu.setEnabled(engineDt.isKataGo);
             } else if (engineDt.isLoaded()) engine[i].setIcon(ready);
             else if (engine[i].getIcon() != null) engine[i].setIcon(null);
           }

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -1326,6 +1326,7 @@ public class Menu extends JMenuBar {
               Lizzie.config.setKataGoRule(rule);
               Lizzie.leelaz.updateKataGoRule(true);
               Lizzie.board.clearAnalysis();
+              Lizzie.frame.refresh();
               try {
                 Lizzie.config.save();
               } catch (IOException es) {


### PR DESCRIPTION
As a minimal support of kata-set-rules, this PR adds "Rule" into "Analysis" menu. It is enabled only when the engine is KataGo. (You need to wait for the initialization of the engine to use this menu.)

I dare to put it under "Analysis" menu rather than "Game" menu as it doesn't read or record `RU[]` in SGF.

#704 is desirable. But I'd like to do only quick hacks for Lizzie.
