### PR TITLE
Show message when autoanalysis is denied

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -1385,7 +1385,10 @@ public class Board implements LeelazListener {
       Lizzie.leelaz.removeListener(this);
       analysisMode = false;
     } else {
-      if (!getNextMove().isPresent()) return;
+      if (!getNextMove().isPresent()) {
+        JOptionPane.showMessageDialog(null, "No next move.");
+        return;
+      }
       String answer =
           JOptionPane.showInputDialog(
               "# playouts for analysis (e.g. 100 (fast) or 50000 (slow)): ");


### PR DESCRIPTION
Lizzie ignores auto-analysis silently when we are at the end of the game. This confuses me every time. So I added a message in this case.

I also tried to rewind the game automatically before running auto-analysis in this case. But it is troublesome if we are not on the main branch in the variation tree.
