### PR TITLE
Fix D key (toggle "show KataGo score mean")

### DIFF
--- a/src/main/java/featurecat/lizzie/Config.java
+++ b/src/main/java/featurecat/lizzie/Config.java
@@ -50,10 +50,8 @@ public class Config {
   public double minPlayoutRatioForStats = 0.1;
   public boolean showLcbWinrate = false;
 
-  public boolean showKataGoScoreMean = true;
   public boolean showKataGoBoardScoreMean = false;
   public boolean kataGoScoreMeanAlwaysBlack = false;
-  public boolean kataGoNotShowWinrate = false;
   public boolean showKataGoEstimate = false;
   public boolean showKataGoEstimateOnSubboard = true;
   public boolean showKataGoEstimateOnMainboard = true;
@@ -236,10 +234,8 @@ public class Config {
     shadowSize = theme.shadowSize();
     showLcbWinrate = config.getJSONObject("leelaz").optBoolean("show-lcb-winrate");
 
-    showKataGoScoreMean = uiConfig.optBoolean("show-katago-scoremean", true);
     showKataGoBoardScoreMean = uiConfig.optBoolean("show-katago-boardscoremean", false);
     kataGoScoreMeanAlwaysBlack = uiConfig.optBoolean("katago-scoremean-alwaysblack", false);
-    kataGoNotShowWinrate = uiConfig.optBoolean("katago-notshow-winrate", false);
     showKataGoEstimate = uiConfig.optBoolean("show-katago-estimate", false);
     showKataGoEstimateOnSubboard = uiConfig.optBoolean("show-katago-estimate-onsubboard", true);
     showKataGoEstimateOnMainboard = uiConfig.optBoolean("show-katago-estimate-onmainboard", true);
@@ -547,10 +543,8 @@ public class Config {
     ui.put("replay-branch-interval-seconds", 1.0);
     ui.put("gtp-console-style", defaultGtpConsoleStyle);
     ui.put("panel-ui", false);
-    ui.put("show-katago-scoremean", true);
     ui.put("show-katago-boardscoremean", false);
     ui.put("katago-scoremean-alwaysblack", false);
-    ui.put("katago-notshow-winrate", false);
     ui.put("show-katago-estimate", false);
     ui.put("show-katago-estimate-onsubboard", true);
     ui.put("show-katago-estimate-onmainboard", true);

--- a/src/main/java/featurecat/lizzie/gui/Input.java
+++ b/src/main/java/featurecat/lizzie/gui/Input.java
@@ -470,23 +470,19 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
         break;
 
       case VK_D:
-        if (Lizzie.leelaz.isKataGo) {
-          if (Lizzie.config.showKataGoScoreMean && Lizzie.config.kataGoNotShowWinrate) {
-            Lizzie.config.showKataGoScoreMean = false;
-            Lizzie.config.kataGoNotShowWinrate = false;
+        if (Lizzie.leelaz.supportScoremean()) {
+          if (Lizzie.config.showScoremeanInSuggestion && !Lizzie.config.showWinrateInSuggestion) {
+            Lizzie.config.showScoremeanInSuggestion = false;
+            Lizzie.config.showWinrateInSuggestion = true;
             break;
           }
-          if (Lizzie.config.showKataGoScoreMean && !Lizzie.config.kataGoNotShowWinrate) {
-            Lizzie.config.kataGoNotShowWinrate = true;
+          if (Lizzie.config.showScoremeanInSuggestion && Lizzie.config.showWinrateInSuggestion) {
+            Lizzie.config.showWinrateInSuggestion = false;
             break;
           }
-          if (Lizzie.config.showKataGoScoreMean) {
-            Lizzie.config.showKataGoScoreMean = false;
-            break;
-          }
-          if (!Lizzie.config.showKataGoScoreMean) {
-            Lizzie.config.showKataGoScoreMean = true;
-            Lizzie.config.kataGoNotShowWinrate = false;
+          if (!Lizzie.config.showScoremeanInSuggestion) {
+            Lizzie.config.showScoremeanInSuggestion = true;
+            Lizzie.config.showWinrateInSuggestion = true;
           }
         } else {
           toggleShowDynamicKomi();


### PR DESCRIPTION
D key was broken after 4f460f825 (ref. #852).