### PR TITLE
not turn off ponder when finished fast analysis.(invoked by keymap a)

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -1412,7 +1412,7 @@ public class Board implements LeelazListener {
       if (!history.getNext().isPresent() || isSuccessivePass) {
         // Reached the end...
         toggleAnalysis();
-        Lizzie.leelaz.togglePonder();
+//        Lizzie.leelaz.togglePonder();
       } else if (bestMoves.isEmpty()) {
         // If we get empty list, something strange happened, ignore notification
       } else {


### PR DESCRIPTION
after analysis the loaded sgf(invoked by key 'a') ,not toggle ponder status .
keep its original status.