### PR TITLE
Revive stoneless movenums in #223, that was disabled by #436 and #586

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
+++ b/src/main/java/featurecat/lizzie/gui/BoardRenderer.java
@@ -627,7 +627,7 @@ public class BoardRenderer {
         variation = suggestedMove.get().variation;
       }
     }
-    Branch branch = new Branch(Lizzie.board, variation, displayedBranchLength);
+    Branch branch = new Branch(Lizzie.board, variation, -1);
     if (isMainBoard) mouseOverCoords = suggestedMove.get().coordinate;
     branchOpt = Optional.of(branch);
     variationOpt = Optional.of(variation);
@@ -766,14 +766,13 @@ public class BoardRenderer {
         if (moveNumberList[Board.getIndex(i, j)] > 0
             && (!branchOpt.isPresent() || !Lizzie.frame.isMouseOver(i, j))) {
           boolean reverse = (moveNumberList[Board.getIndex(i, j)] > maxBranchMoves());
+          if (reverse && !Lizzie.config.showRawBoard) continue;
           if (lastMoveOpt.isPresent() && lastMoveOpt.get()[0] == i && lastMoveOpt.get()[1] == j) {
-            if (reverse) continue;
             g.setColor(Color.RED.brighter()); // stoneHere.isBlack() ? Color.RED.brighter() :
             // Color.BLUE.brighter());
           } else {
             // Draw white letters on black stones nomally.
             // But use black letters for showing black moves without stones.
-            if (reverse) continue;
             g.setColor(stoneHere.isBlack() ^ reverse ? Color.WHITE : Color.BLACK);
           }
 

--- a/src/main/java/featurecat/lizzie/gui/Input.java
+++ b/src/main/java/featurecat/lizzie/gui/Input.java
@@ -216,7 +216,7 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
         } else if (controlIsPressed(e)) {
           undo(10);
         } else {
-          if (Lizzie.frame.isMouseOver) {
+          if (Lizzie.frame.isMouseOver && !Lizzie.config.showRawBoard) {
             Lizzie.frame.doBranch(-1);
           } else {
             undo();
@@ -238,7 +238,7 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
         } else if (controlIsPressed(e)) {
           redo(10);
         } else {
-          if (Lizzie.frame.isMouseOver) {
+          if (Lizzie.frame.isMouseOver && !Lizzie.config.showRawBoard) {
             Lizzie.frame.doBranch(1);
           } else {
             redo();


### PR DESCRIPTION
Usage:

1. Show a suggested variation by mouse hover as usual.
2. Push "z" key (keep holding down) to erase the variation stones and show only their move numbers.
3. Push "up/down arrow" keys to show the variation stones step by step.

Push "up arrow" key just after 2. to erase everything.
