### PR TITLE
Fix: semicolons were ignored in SGF values

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/SGFParser.java
+++ b/src/main/java/featurecat/lizzie/rules/SGFParser.java
@@ -481,6 +481,10 @@ public class SGFParser {
           }
           break;
         case ';':
+          if (inProp) {
+            // support C[a;b;c;]
+            tagContentBuilder.append(c);
+          }
           break;
         default:
           if (subTreeDepth > 1 && !isMultiGo) {
@@ -892,6 +896,7 @@ public class SGFParser {
             }
           }
           break;
+        case ';':
         case ')':
           if (inTag) {
             tagContentBuilder.append(c);
@@ -909,8 +914,6 @@ public class SGFParser {
           inTag = false;
           tagBuilder = new StringBuilder();
           addProperty(props, tag, tagContentBuilder.toString());
-          break;
-        case ';':
           break;
         default:
           if (inTag) {


### PR DESCRIPTION
Lizzie 0.7.4 shows `abc` in the comment area for this SGF. Sabaki and KaTrain shows `a;b;c;` correctly.

~~~
(;SZ[19]C[a;b;c;])
~~~
