### PR TITLE
Fix issues in comment area

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/CommentPane.java
+++ b/src/main/java/featurecat/lizzie/gui/CommentPane.java
@@ -4,19 +4,16 @@ import static java.lang.Math.min;
 
 import featurecat.lizzie.Lizzie;
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Font;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
 import java.awt.event.MouseMotionListener;
-import java.io.IOException;
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
-import javax.swing.JTextPane;
-import javax.swing.text.BadLocationException;
-import javax.swing.text.html.HTMLDocument;
-import javax.swing.text.html.StyleSheet;
+import javax.swing.JTextArea;
 
 /** The window used to display the game. */
 public class CommentPane extends LizziePane {
@@ -24,11 +21,8 @@ public class CommentPane extends LizziePane {
   //  private final BufferStrategy bs;
 
   // Display Comment
-  private HTMLDocument htmlDoc;
-  private LizziePane.HtmlKit htmlKit;
-  private StyleSheet htmlStyle;
   public JScrollPane scrollPane;
-  private JTextPane commentPane;
+  private JTextArea commentPane;
   private JLabel dragPane = new JLabel("Drag out");
   private MouseMotionListener[] mouseMotionListeners;
   private MouseMotionAdapter mouseMotionAdapter;
@@ -38,38 +32,16 @@ public class CommentPane extends LizziePane {
     super(owner);
     setLayout(new BorderLayout(0, 0));
 
-    htmlKit = new LizziePane.HtmlKit();
-    htmlDoc = (HTMLDocument) htmlKit.createDefaultDocument();
-    htmlStyle = htmlKit.getStyleSheet();
-    String style =
-        "body {background:#"
-            + String.format(
-                "%02x%02x%02x",
-                Lizzie.config.commentBackgroundColor.getRed(),
-                Lizzie.config.commentBackgroundColor.getGreen(),
-                Lizzie.config.commentBackgroundColor.getBlue())
-            + "; color:#"
-            + String.format(
-                "%02x%02x%02x",
-                Lizzie.config.commentFontColor.getRed(),
-                Lizzie.config.commentFontColor.getGreen(),
-                Lizzie.config.commentFontColor.getBlue())
-            + "; font-family:"
-            + Lizzie.config.fontName
-            + ", Consolas, Menlo, Monaco, 'Ubuntu Mono', monospace;"
-            + (Lizzie.config.commentFontSize > 0
-                ? "font-size:" + Lizzie.config.commentFontSize
-                : "")
-            + "}";
-    htmlStyle.addRule(style);
-
-    commentPane = new JTextPane();
+    commentPane = new JTextArea();
     commentPane.setBorder(BorderFactory.createEmptyBorder());
-    commentPane.setEditorKit(htmlKit);
-    commentPane.setDocument(htmlDoc);
     commentPane.setText("");
     commentPane.setEditable(false);
     commentPane.setFocusable(false);
+    commentPane.setWrapStyleWord(true);
+    commentPane.setLineWrap(true);
+    // drop alpha for backward compatibility with Lizze 0.7.4
+    commentPane.setBackground(new Color(Lizzie.config.commentBackgroundColor.getRGB()));
+    commentPane.setForeground(new Color(Lizzie.config.commentFontColor.getRGB()));
     commentPane.addMouseListener(
         new MouseAdapter() {
           @Override
@@ -123,19 +95,8 @@ public class CommentPane extends LizziePane {
         }
         Font font = new Font(Lizzie.config.fontName, Font.PLAIN, fontSize);
         commentPane.setFont(font);
-        comment = comment.replaceAll("(\r\n)|(\n)", "<br />").replaceAll(" ", "&nbsp;");
-        addText("<span class=\"comment\">" + comment + "</span>");
+        commentPane.setText(comment);
       }
-    }
-  }
-
-  private void addText(String text) {
-    try {
-      htmlDoc.remove(0, htmlDoc.getLength());
-      htmlKit.insertHTML(htmlDoc, htmlDoc.getLength(), text, 0, 0, null);
-      commentPane.setCaretPosition(htmlDoc.getLength());
-    } catch (BadLocationException | IOException e) {
-      e.printStackTrace();
     }
   }
 

--- a/src/main/java/featurecat/lizzie/gui/CommentPane.java
+++ b/src/main/java/featurecat/lizzie/gui/CommentPane.java
@@ -96,6 +96,7 @@ public class CommentPane extends LizziePane {
         Font font = new Font(Lizzie.config.fontName, Font.PLAIN, fontSize);
         commentPane.setFont(font);
         commentPane.setText(comment);
+        commentPane.setCaretPosition(0);
       }
     }
   }

--- a/src/main/java/featurecat/lizzie/gui/CommentPane.java
+++ b/src/main/java/featurecat/lizzie/gui/CommentPane.java
@@ -3,7 +3,6 @@ package featurecat.lizzie.gui;
 import static java.lang.Math.min;
 
 import featurecat.lizzie.Lizzie;
-import featurecat.lizzie.util.Utils;
 import java.awt.BorderLayout;
 import java.awt.Font;
 import java.awt.event.MouseAdapter;
@@ -124,7 +123,7 @@ public class CommentPane extends LizziePane {
         }
         Font font = new Font(Lizzie.config.fontName, Font.PLAIN, fontSize);
         commentPane.setFont(font);
-        comment = Utils.escapeHTML(comment);
+        comment = comment.replaceAll("(\r\n)|(\n)", "<br />").replaceAll(" ", "&nbsp;");
         addText("<span class=\"comment\">" + comment + "</span>");
       }
     }

--- a/src/main/java/featurecat/lizzie/gui/CommentPane.java
+++ b/src/main/java/featurecat/lizzie/gui/CommentPane.java
@@ -3,6 +3,7 @@ package featurecat.lizzie.gui;
 import static java.lang.Math.min;
 
 import featurecat.lizzie.Lizzie;
+import featurecat.lizzie.util.Utils;
 import java.awt.BorderLayout;
 import java.awt.Font;
 import java.awt.event.MouseAdapter;
@@ -123,7 +124,7 @@ public class CommentPane extends LizziePane {
         }
         Font font = new Font(Lizzie.config.fontName, Font.PLAIN, fontSize);
         commentPane.setFont(font);
-        comment = comment.replaceAll("(\r\n)|(\n)", "<br />").replaceAll(" ", "&nbsp;");
+        comment = Utils.escapeHTML(comment);
         addText("<span class=\"comment\">" + comment + "</span>");
       }
     }

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -44,8 +44,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.imageio.ImageIO;
 import javax.swing.*;
-import javax.swing.text.html.HTMLDocument;
-import javax.swing.text.html.StyleSheet;
 import org.json.JSONArray;
 
 /** The window used to display the game. */
@@ -104,11 +102,8 @@ public class LizzieFrame extends MainFrame {
   private boolean isReplayVariation = false;
 
   // Display Comment
-  private HTMLDocument htmlDoc;
-  private LizziePane.HtmlKit htmlKit;
-  private StyleSheet htmlStyle;
   private JScrollPane scrollPane;
-  private JTextPane commentPane;
+  private JTextArea commentPane;
   private BufferedImage cachedCommentImage = new BufferedImage(1, 1, TYPE_INT_ARGB);
   private String cachedComment;
   private Rectangle commentRect;
@@ -174,35 +169,14 @@ public class LizzieFrame extends MainFrame {
       setExtendedState(Frame.MAXIMIZED_BOTH);
     }
 
-    htmlKit = new LizziePane.HtmlKit();
-    htmlDoc = (HTMLDocument) htmlKit.createDefaultDocument();
-    htmlStyle = htmlKit.getStyleSheet();
-    String style =
-        "body {background:#"
-            + String.format(
-                "%02x%02x%02x",
-                Lizzie.config.commentBackgroundColor.getRed(),
-                Lizzie.config.commentBackgroundColor.getGreen(),
-                Lizzie.config.commentBackgroundColor.getBlue())
-            + "; color:#"
-            + String.format(
-                "%02x%02x%02x",
-                Lizzie.config.commentFontColor.getRed(),
-                Lizzie.config.commentFontColor.getGreen(),
-                Lizzie.config.commentFontColor.getBlue())
-            + "; font-family:"
-            + Lizzie.config.fontName
-            + ", Consolas, Menlo, Monaco, 'Ubuntu Mono', monospace;"
-            + (Lizzie.config.commentFontSize > 0
-                ? "font-size:" + Lizzie.config.commentFontSize
-                : "")
-            + "}";
-    htmlStyle.addRule(style);
-    commentPane = new JTextPane();
+    commentPane = new JTextArea();
     commentPane.setBorder(BorderFactory.createEmptyBorder());
-    commentPane.setEditorKit(htmlKit);
-    commentPane.setDocument(htmlDoc);
     commentPane.setEditable(false);
+    commentPane.setWrapStyleWord(true);
+    commentPane.setLineWrap(true);
+    // drop alpha for backward compatibility with Lizze 0.7.4
+    commentPane.setBackground(new Color(Lizzie.config.commentBackgroundColor.getRGB()));
+    commentPane.setForeground(new Color(Lizzie.config.commentFontColor.getRGB()));
     scrollPane = new JScrollPane();
     scrollPane.setViewportView(commentPane);
     scrollPane.setBorder(null);
@@ -1386,7 +1360,6 @@ public class LizzieFrame extends MainFrame {
     }
     Font font = new Font(Lizzie.config.fontName, Font.PLAIN, fontSize);
     commentPane.setFont(font);
-    comment = comment.replaceAll("(\r\n)|(\n)", "<br />").replaceAll(" ", "&nbsp;");
     commentPane.setText(comment);
     commentPane.setSize(w, h);
     createCommentImage(!comment.equals(this.cachedComment), w, h);

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1386,7 +1386,7 @@ public class LizzieFrame extends MainFrame {
     }
     Font font = new Font(Lizzie.config.fontName, Font.PLAIN, fontSize);
     commentPane.setFont(font);
-    comment = comment.replaceAll("(\r\n)|(\n)", "<br />").replaceAll(" ", "&nbsp;");
+    comment = Utils.escapeHTML(comment);
     commentPane.setText(comment);
     commentPane.setSize(w, h);
     createCommentImage(!comment.equals(this.cachedComment), w, h);

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1386,7 +1386,7 @@ public class LizzieFrame extends MainFrame {
     }
     Font font = new Font(Lizzie.config.fontName, Font.PLAIN, fontSize);
     commentPane.setFont(font);
-    comment = Utils.escapeHTML(comment);
+    comment = comment.replaceAll("(\r\n)|(\n)", "<br />").replaceAll(" ", "&nbsp;");
     commentPane.setText(comment);
     commentPane.setSize(w, h);
     createCommentImage(!comment.equals(this.cachedComment), w, h);

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1263,7 +1263,8 @@ public class LizzieFrame extends MainFrame {
     if (Lizzie.config.showComment && commentRect.contains(e.getX(), e.getY())) {
       scrollPane.dispatchEvent(e);
       createCommentImage(true, commentRect.width, commentRect.height);
-      getGraphics()
+      mainPanel
+          .getGraphics()
           .drawImage(
               cachedCommentImage,
               commentRect.x,

--- a/src/main/java/featurecat/lizzie/util/Utils.java
+++ b/src/main/java/featurecat/lizzie/util/Utils.java
@@ -112,16 +112,6 @@ public class Utils {
     }
   }
 
-  public static String escapeHTML(String text) {
-    return text.replaceAll("&", "&amp;")
-        .replaceAll("<", "&lt;")
-        .replaceAll(">", "&gt;")
-        .replaceAll("\"", "&quot;")
-        .replaceAll("'", "&#39;")
-        .replaceAll(" ", "&nbsp;")
-        .replaceAll("(\r\n)|(\n)", "<br />");
-  }
-
   public static double lastWinrateDiff(BoardHistoryNode node) {
 
     // Last winrate

--- a/src/main/java/featurecat/lizzie/util/Utils.java
+++ b/src/main/java/featurecat/lizzie/util/Utils.java
@@ -112,6 +112,16 @@ public class Utils {
     }
   }
 
+  public static String escapeHTML(String text) {
+    return text.replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll("\"", "&quot;")
+        .replaceAll("'", "&#39;")
+        .replaceAll(" ", "&nbsp;")
+        .replaceAll("(\r\n)|(\n)", "<br />");
+  }
+
   public static double lastWinrateDiff(BoardHistoryNode node) {
 
     // Last winrate


### PR DESCRIPTION
Issue A:

#676 (word wrap). Compared to #696, this PR will be more friendly with the existing code of Lizzie 0.7.4.

~~~
(;SZ[19]C[long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long line
and
looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong line])
~~~

Issue B:

In Panel UI, comments with many lines are scrolled to the bottom initially. The top lines should be visible initially for convenience.

(Try the sample SGF in #877.)

Issue C:

On Lizzie 0.7.4, `score  5` is shown in the comment area by the following SGF due to insufficient HTML escaping. It should be `score < 5`.

~~~
(;SZ[19]C[score < 5])
~~~

Issue D:

1. Start Lizzie 0.7.4 with Normal UI (not Panel UI) and paste the following SGF.
2. Move the mouse cursor to the center of the comment area (the black rectangle at the bottom right)
3. Move the mouse wheel. Then the comment area is moved upward.
4. Move the mouse cursor into the main board. Then the comment area returns to the normal position.

I expect nothing happens in the step 3.

~~~
(;SZ[19]C[abc])
~~~

In addition, this PR may also help future implementation of #806. (only in Panel UI because of #877)

I dare to keep the obsolete name `commentPane`, that is not JTextPane but JTextArea now. I'd like to make changes as small as possible to avoid conflicts with other patches.
