### PR TITLE
Add "Edit/Copy comment" into Game menu

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/CommentPane.java
+++ b/src/main/java/featurecat/lizzie/gui/CommentPane.java
@@ -76,6 +76,13 @@ public class CommentPane extends LizziePane {
           public void mouseClicked(MouseEvent e) {
             Lizzie.frame.getFocus();
           }
+
+          @Override
+          public void mousePressed(MouseEvent e) {
+            if (e.getButton() == MouseEvent.BUTTON1 && e.getClickCount() == 2) {
+              Lizzie.frame.editComment();
+            }
+          }
         });
     scrollPane = new JScrollPane();
     scrollPane.setBorder(BorderFactory.createEmptyBorder());

--- a/src/main/java/featurecat/lizzie/gui/Input.java
+++ b/src/main/java/featurecat/lizzie/gui/Input.java
@@ -391,7 +391,9 @@ public class Input implements MouseListener, KeyListener, MouseWheelListener, Mo
         break;
 
       case VK_C:
-        if (controlIsPressed(e)) {
+        if (controlIsPressed(e) && e.isShiftDown()) {
+          Lizzie.frame.copyCommentToClipboard();
+        } else if (controlIsPressed(e)) {
           Lizzie.frame.copySgf();
         } else {
           Lizzie.config.toggleCoordinates();

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -221,6 +221,11 @@ public class LizzieFrame extends MainFrame {
     createBufferStrategy(2);
     bs = getBufferStrategy();
 
+    // avoid IME issue
+    // https://github.com/featurecat/lizzie/pull/880#issuecomment-800804632
+    // https://github.com/yzyray/lizzie_adv/commit/e5e8be01b4e072615250e4c4cc8462938b7c0332
+    mainPanel.enableInputMethods(false);
+
     Input input = new Input();
 
     mainPanel.addMouseListener(input);

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1186,6 +1186,8 @@ public class LizzieFrame extends MainFrame {
           Lizzie.board.goToMoveNumberBeyondBranch(moveNumber);
         }
       }
+    } else if (Lizzie.config.showComment && commentRect.contains(x, y)) {
+      editComment();
     }
   }
 

--- a/src/main/java/featurecat/lizzie/gui/LizzieMain.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieMain.java
@@ -230,6 +230,11 @@ public class LizzieMain extends MainFrame {
 
     setVisible(true);
 
+    // avoid IME issue
+    // https://github.com/featurecat/lizzie/pull/880#issuecomment-800804632
+    // https://github.com/yzyray/lizzie_adv/commit/e5e8be01b4e072615250e4c4cc8462938b7c0332
+    enableInputMethods(false);
+
     input = new Input();
     //  addMouseListener(input);
     addKeyListener(input);

--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -27,6 +27,8 @@ import java.util.ResourceBundle;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import org.json.JSONObject;
 
@@ -158,6 +160,25 @@ public abstract class MainFrame extends JFrame {
   public abstract void copySgf();
 
   public abstract void pasteSgf();
+
+  public void editComment() {
+    String oldComment = Lizzie.board.getHistory().getData().comment;
+    // https://stackoverflow.com/questions/7765478/how-to-add-text-area-on-joptionpane
+    // https://stackoverflow.com/a/55678093
+    JTextArea textArea = new JTextArea(oldComment);
+    textArea.setColumns(40);
+    textArea.setRows(20);
+    textArea.setLineWrap(true);
+    textArea.setWrapStyleWord(true);
+    textArea.setSize(textArea.getPreferredSize().width, textArea.getPreferredSize().height);
+    int ret =
+        JOptionPane.showConfirmDialog(
+            null, new JScrollPane(textArea), "Comment", JOptionPane.OK_CANCEL_OPTION);
+    if (ret == JOptionPane.OK_OPTION) {
+      Lizzie.board.getHistory().getData().comment = textArea.getText();
+      refresh();
+    }
+  }
 
   public void copyCommentToClipboard() {
     String comment = Lizzie.board.getHistory().getData().comment;

--- a/src/main/java/featurecat/lizzie/gui/MainFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MainFrame.java
@@ -12,6 +12,10 @@ import java.awt.Font;
 import java.awt.FontFormatException;
 import java.awt.HeadlessException;
 import java.awt.LayoutManager;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.io.File;
@@ -154,6 +158,18 @@ public abstract class MainFrame extends JFrame {
   public abstract void copySgf();
 
   public abstract void pasteSgf();
+
+  public void copyCommentToClipboard() {
+    String comment = Lizzie.board.getHistory().getData().comment;
+    if (comment.isEmpty()) return;
+    try {
+      Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+      Transferable transferableString = new StringSelection(comment);
+      clipboard.setContents(transferableString, null);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
 
   public void setPlayers(String whitePlayer, String blackPlayer) {
     playerTitle = String.format("(%s [W] vs %s [B])", whitePlayer, blackPlayer);

--- a/src/main/java/featurecat/lizzie/gui/Menu.java
+++ b/src/main/java/featurecat/lizzie/gui/Menu.java
@@ -1162,6 +1162,29 @@ public class Menu extends JMenuBar {
           }
         });
     gameMenu.add(pass);
+
+    gameMenu.addSeparator();
+
+    final JMenuItem editComment = new JMenuItem("Edit comment");
+    editComment.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            Lizzie.frame.editComment();
+          }
+        });
+    gameMenu.add(editComment);
+
+    final JMenuItem copyComment = new JMenuItem("Copy comment(Ctrl+Shift+C)");
+    copyComment.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            Lizzie.frame.copyCommentToClipboard();
+          }
+        });
+    gameMenu.add(copyComment);
+
     gameMenu.addSeparator();
 
     final JMenuItem clearBoard = new JMenuItem(resourceBundle.getString("Menu.game.clearBoard"));


### PR DESCRIPTION
Alternatively...

* Edit comment: Double-click on the comment area (the black rectangle at the bottom right)
* Copy comment to clipboard: Ctrl-Shift-C

This PR is just a workaround for #806 until someone will implement #806 itself.
