### PR TITLE
Fix: Engine number in menu was not updated for preloaded engines

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -123,6 +123,9 @@ public class EngineManager {
       }
       Lizzie.board.restoreMoveNumber();
       this.currentEngineNo = index;
+      if (curEng.preload && newEng.preload) {
+        updateEngineIcon();
+      }
       if (!curEng.preload) {
         curEng.normalQuit();
       }


### PR DESCRIPTION
Fix the following issue reported by @hebaeba.

1. Check "Preload" of Engine 2 in Settings > Engine.
2. Restart Lizzie. "Engine 0: XXXX" is shown on the menu bar.
3. Wait for a while so that Engine 2 is started in background.
4. Switch to "Engine 2" from the above "Engine 0: XXXX".
5. "Engine 0: XXXX" is still shown on the menu bar. I expect "Engine 2: YYYY".
