### PR TITLE
Fix #889 (wrong color to play)

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -823,15 +823,10 @@ public class Board implements LeelazListener {
 
   /** Restore move number by node */
   public void restoreMoveNumber(BoardHistoryNode node) {
-    Stone[] stones = history.getStones();
-    for (int i = 0; i < stones.length; i++) {
-      Stone stone = stones[i];
-      if (stone.isBlack() || stone.isWhite()) {
-        int y = i % Board.boardWidth;
-        int x = (i - y) / Board.boardHeight;
-        Lizzie.leelaz.playMove(stone, convertCoordinatesToName(x, y));
-      }
-    }
+    Lizzie.leelaz.clear();
+    boolean blackToPlay = node.getData().blackToPlay;
+    restoreInitialStones(blackToPlay);
+    restoreInitialStones(!blackToPlay);
     int moveNumber = node.getData().moveNumber;
     if (moveNumber > 0) {
       if (node.isMainTrunk()) {
@@ -839,6 +834,18 @@ public class Board implements LeelazListener {
       } else {
         // If in Branch, restore by the back routing
         goToMoveNumberByBackChildren(moveNumber);
+      }
+    }
+  }
+
+  private void restoreInitialStones(boolean isBlack) {
+    Stone[] stones = history.getStones();
+    for (int i = 0; i < stones.length; i++) {
+      Stone stone = stones[i];
+      if (isBlack ? stone.isBlack() : stone.isWhite()) {
+        int y = i % Board.boardWidth;
+        int x = (i - y) / Board.boardHeight;
+        Lizzie.leelaz.playMove(stone, convertCoordinatesToName(x, y));
       }
     }
   }


### PR DESCRIPTION
(Caution: You also need to apply #766 to handle initial stones correctly in Lizzie 0.7.4.)

This patch fixes both #889 and another issue (handicap stones are not cleared for background engines) in Lizzie 0.7.3:

1. Start Lizzie.
2. Paste `(;AB[dd])`.
3. Switch the engine to Engine1.
4. Click "ClearBoard" button in the toolbar.
5. Switch the engine to Engine0 again.
6. Click "Analyze > Clear analysis" in the menu.

The board is empty at 6, but no candidate appears around the top left corner.

## Notes

This patch is just a workaround. It will be better to specify `player` explicitly in `lz-analyze` like `lz-analyze b 10` instead of `lz-analyze 10`. I did not do it this time because I am not sure whether `Lizzie.board.getData().blackToPlay` (or `Lizzie.board.getHistory().isBlacksTurn()`) is always updated correctly before pondering.
