### PR TITLE
Add tooltips for truncated long labels in config dialog

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -82,6 +82,7 @@ import javax.swing.LayoutStyle.ComponentPlacement;
 import javax.swing.ListCellRenderer;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 import javax.swing.border.Border;
 import javax.swing.event.ChangeEvent;
@@ -113,9 +114,9 @@ public class ConfigDialog extends JDialog {
   private List<String> fontList;
   private Theme theme;
 
-  public JPanel uiTab;
-  public JPanel themeTab;
-  public JPanel aboutTab;
+  public PanelWithToolTip uiTab;
+  public PanelWithToolTip themeTab;
+  public PanelWithToolTip aboutTab;
   public JButton okButton;
 
   // Engine Tab
@@ -256,7 +257,7 @@ public class ConfigDialog extends JDialog {
     tabbedPane = new JTabbedPane(JTabbedPane.TOP);
     getContentPane().add(tabbedPane, BorderLayout.CENTER);
 
-    JPanel engineTab = new JPanel();
+    PanelWithToolTip engineTab = new PanelWithToolTip();
     tabbedPane.addTab(resourceBundle.getString("LizzieConfig.title.engine"), null, engineTab, null);
     engineTab.setLayout(null);
 
@@ -658,17 +659,17 @@ public class ConfigDialog extends JDialog {
     chkPrintEngineLog.setBounds(167, 425, 201, 23);
     engineTab.add(chkPrintEngineLog);
 
-    uiTab = new JPanel();
+    uiTab = new PanelWithToolTip();
     tabbedPane.addTab(resourceBundle.getString("LizzieConfig.title.ui"), null, uiTab, null);
     uiTab.setLayout(null);
 
     // Theme Tab
-    themeTab = new JPanel();
+    themeTab = new PanelWithToolTip();
     tabbedPane.addTab(resourceBundle.getString("LizzieConfig.title.theme"), null, themeTab, null);
     themeTab.setLayout(null);
 
     // About Tab
-    aboutTab = new JPanel();
+    aboutTab = new PanelWithToolTip();
     tabbedPane.addTab(resourceBundle.getString("LizzieConfig.title.about"), null, aboutTab, null);
 
     JLabel lblLizzieName = new JLabel("Lizzie " + Lizzie.lizzieVersion);
@@ -1816,6 +1817,28 @@ public class ConfigDialog extends JDialog {
     protected void done() {
       okButton.setEnabled(true);
       pnlBoardPreview.repaint();
+    }
+  }
+
+  private class PanelWithToolTip extends JPanel {
+    public void add(JLabel label) {
+      super.add(label);
+      String text = label.getText();
+      String displayedText =
+          SwingUtilities.layoutCompoundLabel(
+              label,
+              label.getFontMetrics(label.getFont()),
+              text,
+              label.getIcon(),
+              label.getVerticalAlignment(),
+              label.getHorizontalAlignment(),
+              label.getVerticalTextPosition(),
+              label.getHorizontalTextPosition(),
+              label.getBounds(),
+              label.getBounds(),
+              label.getBounds(),
+              label.getIconTextGap());
+      if (displayedText != text) label.setToolTipText(text);
     }
   }
 

--- a/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
+++ b/src/main/java/featurecat/lizzie/gui/ConfigDialog.java
@@ -1822,13 +1822,14 @@ public class ConfigDialog extends JDialog {
 
   private class PanelWithToolTip extends JPanel {
     public void add(JLabel label) {
-      super.add(label);
-      String text = label.getText();
+      String texts[] = label.getText().split("\n", 2);
+      String labelText = texts[0];
+      String toolTipText = (texts.length >= 2) ? texts[1] : labelText;
       String displayedText =
           SwingUtilities.layoutCompoundLabel(
               label,
               label.getFontMetrics(label.getFont()),
-              text,
+              labelText,
               label.getIcon(),
               label.getVerticalAlignment(),
               label.getHorizontalAlignment(),
@@ -1838,7 +1839,9 @@ public class ConfigDialog extends JDialog {
               label.getBounds(),
               label.getBounds(),
               label.getIconTextGap());
-      if (displayedText != text) label.setToolTipText(text);
+      label.setText(labelText);
+      if (displayedText != toolTipText) label.setToolTipText(toolTipText);
+      super.add(label);
     }
   }
 


### PR DESCRIPTION
workaround for unreadable labels, e.g. #892
