### PR TITLE
Fix IndexOutOfBoundsException in the initial run

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/EngineManager.java
+++ b/src/main/java/featurecat/lizzie/analysis/EngineManager.java
@@ -172,6 +172,9 @@ public class EngineManager {
                             i -> {
                               String cmd = m.optString(i);
                               int index = i + 1;
+                              while (engineList.size() < index + 1) {
+                                engineList.add(null);
+                              }
                               if (index != currentEngineNo) {
                                 updateEngine(
                                     index,


### PR DESCRIPTION
1. Delete the file `config.txt`.
2. Start Lizzie 0.7.4.
3. Open the menu Settings > Engine and click `ok` button.

Then I get the following error.

~~~
Exception in thread "Thread-2" java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248)
        at java.base/java.util.Objects.checkIndex(Objects.java:372)
        at java.base/java.util.ArrayList.get(ArrayList.java:459)
        at featurecat.lizzie.analysis.EngineManager.updateEngine(EngineManager.java:231)
~~~
