### PR TITLE
Fix: update pondering message after max-analyze-time-minutes

### DIFF
--- a/src/main/java/featurecat/lizzie/analysis/Leelaz.java
+++ b/src/main/java/featurecat/lizzie/analysis/Leelaz.java
@@ -376,6 +376,7 @@ public class Leelaz {
           if (System.currentTimeMillis() - startPonderTime > maxAnalyzeTimeMillis
               && !Lizzie.board.inAnalysisMode()) {
             togglePonder();
+            Lizzie.frame.refresh();
           }
         }
       } else if (line.contains(" -> ")) {


### PR DESCRIPTION
"pondering on" message was not updated after max-analyze-time-minutes. thx > @hebaeba.

Though I also wrote the following dialog, it is not included in this PR because I am afraid that such warnings may be annoying. How do you think?

~~~
Paused by the time limit (XX min from yyyy-MM-dd HH:mm).

Push spacebar to resume.
Click "Settings > Engine" menu to change "Max Analyze Time".
~~~

(d9f755b5 in https://github.com/kaorahi/lizzie/tree/fix_max_time2)
