### PR TITLE
Show change of winrate bar

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1030,6 +1030,20 @@ public class LizzieFrame extends MainFrame {
       g.setColor(Color.BLACK);
       g.fillRect(barPosxB, barPosY, barWidthB, barHeight);
 
+      // Draw change of winrate bars
+      if (validWinrate && validLastWinrate) {
+        double gain = 100 - lastWR - curWR;
+        double blackLastWR = Lizzie.board.getData().blackToPlay ? 100 - lastWR : lastWR;
+        int lastPosxW = barPosxB + (int) (blackLastWR * maxBarwidth / 100);
+        int diffPosX = Math.min(barPosxW, lastPosxW);
+        int diffWidth = Math.abs(barPosxW - lastPosxW);
+        Stroke oldstroke = g.getStroke();
+        g.setStroke(new BasicStroke(strokeRadius));
+        g.setColor(gain >= 0 ? Color.GREEN : Color.RED);
+        g.drawRect(diffPosX, barPosY, diffWidth, barHeight);
+        g.setStroke(oldstroke);
+      }
+
       // Show percentage above bars
       g.setColor(Color.WHITE);
       g.drawString(

--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1032,15 +1032,12 @@ public class LizzieFrame extends MainFrame {
 
       // Draw change of winrate bars
       if (validWinrate && validLastWinrate) {
-        double gain = 100 - lastWR - curWR;
         double blackLastWR = Lizzie.board.getData().blackToPlay ? 100 - lastWR : lastWR;
         int lastPosxW = barPosxB + (int) (blackLastWR * maxBarwidth / 100);
-        int diffPosX = Math.min(barPosxW, lastPosxW);
-        int diffWidth = Math.abs(barPosxW - lastPosxW);
         Stroke oldstroke = g.getStroke();
         g.setStroke(new BasicStroke(strokeRadius));
-        g.setColor(gain >= 0 ? Color.GREEN : Color.RED);
-        g.drawRect(diffPosX, barPosY, diffWidth, barHeight);
+        g.setColor(Color.GRAY);
+        g.drawLine(lastPosxW, barPosY, lastPosxW, barPosY + barHeight);
         g.setStroke(oldstroke);
       }
 

--- a/src/main/java/featurecat/lizzie/gui/WinratePane.java
+++ b/src/main/java/featurecat/lizzie/gui/WinratePane.java
@@ -253,15 +253,12 @@ public class WinratePane extends LizziePane {
 
       // Draw change of winrate bars
       if (validWinrate && validLastWinrate) {
-        double gain = 100 - lastWR - curWR;
         double blackLastWR = Lizzie.board.getData().blackToPlay ? 100 - lastWR : lastWR;
         int lastPosxW = barPosxB + (int) (blackLastWR * maxBarwidth / 100);
-        int diffPosX = Math.min(barPosxW, lastPosxW);
-        int diffWidth = Math.abs(barPosxW - lastPosxW);
         Stroke oldstroke = g.getStroke();
         g.setStroke(new BasicStroke(strokeRadius));
-        g.setColor(gain >= 0 ? Color.GREEN : Color.RED);
-        g.drawRect(diffPosX, barPosY, diffWidth, barHeight);
+        g.setColor(Color.GRAY);
+        g.drawLine(lastPosxW, barPosY, lastPosxW, barPosY + barHeight);
         g.setStroke(oldstroke);
       }
 

--- a/src/main/java/featurecat/lizzie/gui/WinratePane.java
+++ b/src/main/java/featurecat/lizzie/gui/WinratePane.java
@@ -251,6 +251,20 @@ public class WinratePane extends LizziePane {
       g.setColor(Color.BLACK);
       g.fillRect(barPosxB, barPosY, barWidthB, barHeight);
 
+      // Draw change of winrate bars
+      if (validWinrate && validLastWinrate) {
+        double gain = 100 - lastWR - curWR;
+        double blackLastWR = Lizzie.board.getData().blackToPlay ? 100 - lastWR : lastWR;
+        int lastPosxW = barPosxB + (int) (blackLastWR * maxBarwidth / 100);
+        int diffPosX = Math.min(barPosxW, lastPosxW);
+        int diffWidth = Math.abs(barPosxW - lastPosxW);
+        Stroke oldstroke = g.getStroke();
+        g.setStroke(new BasicStroke(strokeRadius));
+        g.setColor(gain >= 0 ? Color.GREEN : Color.RED);
+        g.drawRect(diffPosX, barPosY, diffWidth, barHeight);
+        g.setStroke(oldstroke);
+      }
+
       // Show percentage above bars
       g.setColor(Color.WHITE);
       g.drawString(


### PR DESCRIPTION
This patch imports one of my favorite features from LizGoban. The change of the winrate bar is shown as the green (= good move) or red (= bad move) rectangle.

Are there more suitable colors for Lizzie?

![wrbar_diff](https://user-images.githubusercontent.com/38910552/132013981-ca52e0ca-34c4-4bea-ba8c-65114fd187d0.png)
