### PR TITLE
Fix incomplete updating of the board after its size change

### DIFF
--- a/src/main/java/featurecat/lizzie/rules/Board.java
+++ b/src/main/java/featurecat/lizzie/rules/Board.java
@@ -221,6 +221,14 @@ public class Board implements LeelazListener {
       clear();
       Lizzie.leelaz.boardSize(boardWidth, boardHeight);
       Lizzie.frame.setForceRefresh(true);
+      Lizzie.frame.refresh();
+      Lizzie.frame.removeEstimateRect();
+      if (Lizzie.leelaz.isPondering()) {
+        // The above boardSize() stops pondering.
+        // To restart it, call togglePonder() twice.
+        Lizzie.leelaz.togglePonder(); // turn off
+        Lizzie.leelaz.togglePonder(); // turn on ==> restart pondering
+      }
     }
   }
 


### PR DESCRIPTION
When the board size is changed from the menu (Settings > View), the following issues occur in 0.7.4:

* If pondering is off, the small squares representing the outdated ownership estimation remain on the board. Furthermore, the part of the board outside the config dialog is not refreshed in the normal UI.
* If pondering is on, the background analysis stops, although it is displayed as "on".

This patch resolves these issues.
